### PR TITLE
Add possibility to choose config file, implement temporary sessions

### DIFF
--- a/pyrogram/client/client.py
+++ b/pyrogram/client/client.py
@@ -320,7 +320,7 @@ class Client:
             self.user_id = s["user_id"]
 
     def save_session(self):
-        if session_name is not None:
+        if self.session_name is not None:
             auth_key = base64.b64encode(self.auth_key).decode()
             auth_key = [auth_key[i: i + 43] for i in range(0, len(auth_key), 43)]
 


### PR DESCRIPTION
- Added the possibility to choose a configuration file by providing its path when initializing the `Client`, instead of using the previously hard-coded "config.ini" file
- Allowing to set the `session_name` to `None` in order to make it "temporary", so that it won't be saved