### PR TITLE
Error [400 PHONE_NUMBER_BANNED]

### DIFF
--- a/compiler/error/source/400_BAD_REQUEST.tsv
+++ b/compiler/error/source/400_BAD_REQUEST.tsv
@@ -43,3 +43,4 @@ VOLUME_LOC_NOT_FOUND	The volume location can't be found
 FILE_ID_INVALID	The file id is invalid
 LOCATION_INVALID	The file location is invalid
 CHAT_ADMIN_REQUIRED	The method requires admin privileges
+PHONE_NUMBER_BANNED The phone number is banned

--- a/compiler/error/source/400_BAD_REQUEST.tsv
+++ b/compiler/error/source/400_BAD_REQUEST.tsv
@@ -43,4 +43,4 @@ VOLUME_LOC_NOT_FOUND	The volume location can't be found
 FILE_ID_INVALID	The file id is invalid
 LOCATION_INVALID	The file location is invalid
 CHAT_ADMIN_REQUIRED	The method requires admin privileges
-PHONE_NUMBER_BANNED The phone number is banned
+PHONE_NUMBER_BANNED	The phone number is banned

--- a/pyrogram/client/client.py
+++ b/pyrogram/client/client.py
@@ -274,7 +274,7 @@ class Client:
                     )
                 )
                 break
-            except PhoneNumberInvalid as e:
+            except (PhoneNumberInvalid, PhoneNumberBanned) as e:
                 if phone_number_invalid_raises:
                     raise
                 else:
@@ -283,9 +283,6 @@ class Client:
             except FloodWait as e:
                 print(e.MESSAGE.format(x=e.x))
                 time.sleep(e.x)
-            except PhoneNumberBanned as e:
-                log.error(e, exc_info=True)
-                raise
             except Exception as e:
                 log.error(e, exc_info=True)
             else:

--- a/pyrogram/client/client.py
+++ b/pyrogram/client/client.py
@@ -37,7 +37,7 @@ from pyrogram.api.errors import (
     PhoneNumberUnoccupied, PhoneCodeInvalid, PhoneCodeHashEmpty,
     PhoneCodeExpired, PhoneCodeEmpty, SessionPasswordNeeded,
     PasswordHashInvalid, FloodWait, PeerIdInvalid, FilePartMissing,
-    ChatAdminRequired, FirstnameInvalid
+    ChatAdminRequired, FirstnameInvalid, PhoneNumberBanned
 )
 from pyrogram.api.types import (
     User, Chat, Channel,
@@ -283,6 +283,9 @@ class Client:
             except FloodWait as e:
                 print(e.MESSAGE.format(x=e.x))
                 time.sleep(e.x)
+            except PhoneNumberBanned as e:
+                log.error(e, exc_info=True)
+                raise
             except Exception as e:
                 log.error(e, exc_info=True)
             else:


### PR DESCRIPTION
when a phone number is banned by Telegram, Client permanently sends requests because it's an UnknownError and 'def authorize(self)' has the code without 'break' or 'raise':
```            
except Exception as e:
                log.error(e, exc_info=True)
```