### PR TITLE
Error [400 ABOUT_TOO_LONG]

### DIFF
--- a/compiler/error/source/400_BAD_REQUEST.tsv
+++ b/compiler/error/source/400_BAD_REQUEST.tsv
@@ -44,3 +44,4 @@ FILE_ID_INVALID	The file id is invalid
 LOCATION_INVALID	The file location is invalid
 CHAT_ADMIN_REQUIRED	The method requires admin privileges
 PHONE_NUMBER_BANNED	The phone number is banned
+ABOUT_TOO_LONG	The about text is too long


### PR DESCRIPTION
hi there!
add another error that was `UnknownError`. Telegram has 70 characters limitation for user's Bio field, i believe. when you try to use `functions.account.UpdateProfile()` method and pass `about` parameter more than 70 characters, then you get the error::
```
pyrogram.api.errors.error.UnknownError: [520 Unknown error]: {
    "_": "types.RpcError",
    "error_code": 400,
    "error_message": "ABOUT_TOO_LONG"
}
```