### PR TITLE
More flexible media downloads with client.download_(media/photo) and client.get_file

### DIFF
--- a/pyrogram/client/client.py
+++ b/pyrogram/client/client.py
@@ -512,6 +512,10 @@ class Client:
             try:
                 media, file_dir, file_name, done, progress, path = media
 
+                if file_dir is not None:
+                    # Make file_dir if it was specified
+                    os.makedirs(file_dir, exist_ok=True)
+
                 if isinstance(media, types.MessageMediaDocument):
                     document = media.document
 
@@ -2620,7 +2624,8 @@ class Client:
                        file_name: str = None,
                        file_dir: str = 'downloads',
                        block: bool = True,
-                       progress: callable = None):
+                       progress: callable = None
+                       ):
         """Use this method to download the media from a Message.
 
         Args:
@@ -2636,7 +2641,8 @@ class Client:
             file_dir (:obj:`str`, optional):
                 Specify a directory to place the file in if no *file_name* is specified.
                 If *file_dir* is *None*, the current working directory is used. The default
-                value is the "downloads" folder in the current working directory.
+                value is the "downloads" folder in the current working directory.  The
+                directory tree will be created if it does not exist.
 
             block (:obj:`bool`, optional):
                 Blocks the code execution until the file has been downloaded.
@@ -2658,6 +2664,7 @@ class Client:
 
         Raises:
             :class:`pyrogram.Error`
+            :class:`ValueError` if both file_name and file_dir are specified.
         """
 
         if file_name is not None and file_dir is not None:
@@ -2685,6 +2692,7 @@ class Client:
     def download_photo(self,
                        photo: types.Photo or types.UserProfilePhoto or types.ChatPhoto,
                        file_name: str = None,
+                       file_dir: str = None,
                        block: bool = True):
         """Use this method to download a photo not contained inside a Message.
         For example, a photo of a User or a Chat/Channel.
@@ -2696,7 +2704,16 @@ class Client:
                 The photo object.
 
             file_name (:obj:`str`, optional):
-                Specify a custom *file_name* to be used.
+                Specify a custom *file_name* to be used instead of the one provided by Telegram.
+                This parameter is expected to be a full file path to the location you want the
+                photo to be placed. If not specified, the photo will be put into the directory
+                specified by *file_dir* with a generated name.
+
+            file_dir (:obj:`str`, optional):
+                Specify a directory to place the photo in if no *file_name* is specified.
+                If *file_dir* is *None*, the current working directory is used. The default
+                value is the "downloads" folder in the current working directory.  The
+                directory tree will be created if it does not exist.
 
             block (:obj:`bool`, optional):
                 Blocks the code execution until the photo has been downloaded.
@@ -2722,7 +2739,7 @@ class Client:
                 )]
             )
 
-        return self.download_media(photo, file_name, block)
+        return self.download_media(photo, file_name, file_dir, block)
 
     def add_contacts(self, contacts: list):
         """Use this method to add contacts to your Telegram address book.

--- a/pyrogram/client/client.py
+++ b/pyrogram/client/client.py
@@ -516,6 +516,9 @@ class Client:
                     # Make file_dir if it was specified
                     os.makedirs(file_dir, exist_ok=True)
 
+                if file_name is not None:
+                    os.makedirs(os.path.dirname(file_name), exist_ok=True)
+
                 if isinstance(media, types.MessageMediaDocument):
                     document = media.document
 

--- a/pyrogram/client/client.py
+++ b/pyrogram/client/client.py
@@ -24,12 +24,11 @@ import math
 import mimetypes
 import os
 import re
+import shutil
 import struct
 import tempfile
 import threading
 import time
-import shutil
-
 from collections import namedtuple
 from configparser import ConfigParser
 from datetime import datetime
@@ -2617,14 +2616,15 @@ class Client:
                        progress: callable = None):
         """Use this method to download the media from a Message.
 
-        Files are saved in the *downloads* folder.
-
         Args:
             message (:obj:`Message <pyrogram.api.types.Message>`):
                 The Message containing the media.
 
             file_name (:obj:`str`, optional):
-                Specify a custom *file_name* to be used instead of the one provided by Telegram.
+                A custom *file_name* to be used instead of the one provided by Telegram.
+                By default, all files are downloaded in the *downloads* folder in your working directory.
+                You can also specify a path for downloading files in a custom location: paths that end with "/"
+                are considered directories. All non-existent folders will be created automatically.
 
             block (:obj:`bool`, optional):
                 Blocks the code execution until the file has been downloaded.
@@ -2642,7 +2642,7 @@ class Client:
                 The size of the file.
 
         Returns:
-            The relative path of the downloaded file.
+            On success, the absolute path of the downloaded file as string is returned, None otherwise.
 
         Raises:
             :class:`pyrogram.Error`
@@ -2673,21 +2673,22 @@ class Client:
         """Use this method to download a photo not contained inside a Message.
         For example, a photo of a User or a Chat/Channel.
 
-        Photos are saved in the *downloads* folder.
-
         Args:
             photo (:obj:`Photo <pyrogram.api.types.Photo>` | :obj:`UserProfilePhoto <pyrogram.api.types.UserProfilePhoto>` | :obj:`ChatPhoto <pyrogram.api.types.ChatPhoto>`):
                 The photo object.
 
             file_name (:obj:`str`, optional):
-                Specify a custom *file_name* to be used.
+                A custom *file_name* to be used instead of the one provided by Telegram.
+                By default, all photos are downloaded in the *downloads* folder in your working directory.
+                You can also specify a path for downloading photos in a custom location: paths that end with "/"
+                are considered directories. All non-existent folders will be created automatically.
 
             block (:obj:`bool`, optional):
                 Blocks the code execution until the photo has been downloaded.
                 Defaults to True.
 
         Returns:
-            The relative path of the downloaded photo.
+            On success, the absolute path of the downloaded photo as string is returned, None otherwise.
 
         Raises:
             :class:`pyrogram.Error`

--- a/pyrogram/client/client.py
+++ b/pyrogram/client/client.py
@@ -2668,7 +2668,7 @@ class Client:
         """
 
         if file_name is not None and file_dir is not None:
-            ValueError('file_name and file_dir may not be specified together.')
+            raise ValueError('file_name and file_dir may not be specified together.')
 
         if isinstance(message, (types.Message, types.Photo)):
             done = Event()

--- a/pyrogram/client/client.py
+++ b/pyrogram/client/client.py
@@ -574,13 +574,8 @@ class Client:
 
                 if temp_file_path:
                     final_file_path = os.path.join(directory, file_name)
-
-                    try:
-                        os.remove(final_file_path)
-                    except OSError:
-                        pass
-
-                    os.renames(temp_file_path, final_file_path)
+                    os.makedirs(directory, exist_ok=True)
+                    shutil.move(temp_file_path, final_file_path)
             except Exception as e:
                 log.error(e, exc_info=True)
 

--- a/pyrogram/client/client.py
+++ b/pyrogram/client/client.py
@@ -2248,6 +2248,8 @@ class Client:
 
             elif isinstance(file_out, str):
                 f = open(file_out, 'wb')
+                close_file = True
+
             elif hasattr(file_out, 'write'):
                 f = file_out
 
@@ -2367,7 +2369,7 @@ class Client:
         else:
             return file_out
         finally:
-            if close_file and f and hasattr(f, 'close'):
+            if close_file and f is not None:
                 f.close()
             session.stop()
 

--- a/pyrogram/client/client.py
+++ b/pyrogram/client/client.py
@@ -2640,8 +2640,8 @@ class Client:
             file_name (:obj:`str`, optional):
                 Specify a custom *file_name* to be used instead of the one provided by Telegram.
                 This parameter is expected to be a full file path to the location you want the
-                file to be placed. If not specified, the file will be put into the directory
-                specified by *file_dir* with a generated name.
+                file to be placed, or a file like object. If not specified, the file will
+                be put into the directory specified by *file_dir* with a generated name.
 
             file_dir (:obj:`str`, optional):
                 Specify a directory to place the file in if no *file_name* is specified.
@@ -2714,8 +2714,8 @@ class Client:
             file_name (:obj:`str`, optional):
                 Specify a custom *file_name* to be used instead of the one provided by Telegram.
                 This parameter is expected to be a full file path to the location you want the
-                photo to be placed. If not specified, the photo will be put into the directory
-                specified by *file_dir* with a generated name.
+                photo to be placed, or a file like object. If not specified, the photo will
+                be put into the directory specified by *file_dir* with a generated name.
 
             file_dir (:obj:`str`, optional):
                 Specify a directory to place the photo in if no *file_name* is specified.

--- a/pyrogram/client/client.py
+++ b/pyrogram/client/client.py
@@ -2299,6 +2299,17 @@ class Client:
                 cdn_session.start()
 
                 try:
+                    # cant fdopen the closed file descriptor from above
+                    # which is closed due to the with statement in the branch just above
+                    # make a new temp file to write to
+
+                    try:
+                        os.remove(file_name)
+                    except OSError:
+                        pass
+
+                    fd, file_name = tempfile.mkstemp()
+
                     with os.fdopen(fd, "wb") as f:
                         while True:
                             r2 = cdn_session.send(

--- a/pyrogram/client/client.py
+++ b/pyrogram/client/client.py
@@ -35,9 +35,7 @@ from queue import Queue
 from signal import signal, SIGINT, SIGTERM, SIGABRT
 from threading import Event, Thread
 import tempfile
-
 import shutil
-
 import errno
 
 from pyrogram.api import functions, types
@@ -599,7 +597,7 @@ class Client:
                         else:
                             os.makedirs(os.path.dirname(file_name), exist_ok=True)
 
-                        # avoid errors moving between drives on windows
+                        # avoid errors moving between drives/partitions etc.
                         shutil.move(tmp_file_name, os.path.join(download_directory, file_name))
                     except OSError as e:
                         log.error(e, exc_info=True)

--- a/pyrogram/client/client.py
+++ b/pyrogram/client/client.py
@@ -2250,7 +2250,7 @@ class Client:
 
         limit = 1024 * 1024
         offset = 0
-        fd, file_name = tempfile.mkstemp()
+        file_name = None
 
         try:
             r = session.send(
@@ -2262,7 +2262,9 @@ class Client:
             )
 
             if isinstance(r, types.upload.File):
-                with os.fdopen(fd, "wb") as f:
+                with tempfile.NamedTemporaryFile('wb', delete=False) as f:
+                    file_name = f.name
+
                     while True:
                         chunk = r.bytes
 
@@ -2299,7 +2301,8 @@ class Client:
                 cdn_session.start()
 
                 try:
-                    with os.fdopen(fd, "wb") as f:
+                    with tempfile.NamedTemporaryFile('wb', delete=False) as f:
+                        file_name = f.name
                         while True:
                             r2 = cdn_session.send(
                                 functions.upload.GetCdnFile(

--- a/pyrogram/client/client.py
+++ b/pyrogram/client/client.py
@@ -609,7 +609,7 @@ class Client:
                 try:
                     os.remove(tmp_file_name)
                 except OSError as e:
-                    if not e.errno == errno.ENOENT:
+                    if e.errno != errno.ENOENT:
                         log.error(e, exc_info=True)
 
         log.debug("{} stopped".format(name))

--- a/pyrogram/client/client.py
+++ b/pyrogram/client/client.py
@@ -573,7 +573,7 @@ class Client:
                         )
 
                 if temp_file_path:
-                    final_file_path = os.path.join(directory, file_name)
+                    final_file_path = re.sub("\\\\", "/", os.path.join(directory, file_name))
                     os.makedirs(directory, exist_ok=True)
                     shutil.move(temp_file_path, final_file_path)
             except Exception as e:

--- a/pyrogram/client/client.py
+++ b/pyrogram/client/client.py
@@ -2659,6 +2659,10 @@ class Client:
         Raises:
             :class:`pyrogram.Error`
         """
+
+        if file_name is not None and file_dir is not None:
+            ValueError('file_name and file_dir may not be specified together.')
+
         if isinstance(message, (types.Message, types.Photo)):
             done = Event()
             path = [None]

--- a/pyrogram/client/client.py
+++ b/pyrogram/client/client.py
@@ -2247,10 +2247,9 @@ class Client:
                 version=version
             )
 
-        fd, file_name = tempfile.mkstemp()
-
         limit = 1024 * 1024
         offset = 0
+        file_name = None
 
         try:
             r = session.send(
@@ -2260,6 +2259,8 @@ class Client:
                     limit=limit
                 )
             )
+
+            fd, file_name = tempfile.mkstemp()
 
             if isinstance(r, types.upload.File):
                 with os.fdopen(fd, "wb") as f:
@@ -2374,10 +2375,11 @@ class Client:
         except Exception as e:
             log.error(e, exc_info=True)
 
-            try:
-                os.remove(file_name)
-            except OSError:
-                pass
+            if file_name:
+                try:
+                    os.remove(file_name)
+                except OSError:
+                    pass
         else:
             return file_name
         finally:

--- a/pyrogram/client/client.py
+++ b/pyrogram/client/client.py
@@ -2622,7 +2622,7 @@ class Client:
     def download_media(self,
                        message: types.Message,
                        file_name: str = None,
-                       file_dir: str = 'downloads',
+                       file_dir: str = None,
                        block: bool = True,
                        progress: callable = None
                        ):
@@ -2669,6 +2669,9 @@ class Client:
 
         if file_name is not None and file_dir is not None:
             raise ValueError('file_name and file_dir may not be specified together.')
+
+        if file_name is None and file_dir is None:
+            file_dir = 'downloads'
 
         if isinstance(message, (types.Message, types.Photo)):
             done = Event()

--- a/pyrogram/client/client.py
+++ b/pyrogram/client/client.py
@@ -516,7 +516,7 @@ class Client:
                     # Make file_dir if it was specified
                     os.makedirs(file_dir, exist_ok=True)
 
-                if file_name is not None:
+                if isinstance(file_name, str) and file_name is not None:
                     os.makedirs(os.path.dirname(file_name), exist_ok=True)
 
                 if isinstance(media, types.MessageMediaDocument):

--- a/pyrogram/client/client.py
+++ b/pyrogram/client/client.py
@@ -2299,8 +2299,8 @@ class Client:
                 cdn_session.start()
 
                 try:
-                    # cant fdopen the closed file descriptor from above
-                    # which is closed due to the with statement in the branch just above
+                    # cant fdopen the closed file descriptor which could be closed due
+                    # to the with statement in the branch just above.
                     # make a new temp file to write to
 
                     try:

--- a/pyrogram/client/client.py
+++ b/pyrogram/client/client.py
@@ -28,6 +28,8 @@ import struct
 import tempfile
 import threading
 import time
+import shutil
+
 from collections import namedtuple
 from configparser import ConfigParser
 from datetime import datetime

--- a/pyrogram/client/client.py
+++ b/pyrogram/client/client.py
@@ -510,7 +510,7 @@ class Client:
                 break
 
             try:
-                media, file_name, done, progress, path = media
+                media, file_dir, file_name, done, progress, path = media
 
                 if isinstance(media, types.MessageMediaDocument):
                     document = media.document
@@ -536,6 +536,8 @@ class Client:
                                 elif isinstance(i, types.DocumentAttributeAnimated):
                                     file_name = file_name.replace("doc", "gif")
 
+                            file_name = os.path.join(file_dir if file_dir is not None else '', file_name)
+
                         self.get_file(
                             dc_id=document.dc_id,
                             id=document.id,
@@ -557,6 +559,8 @@ class Client:
                                 datetime.fromtimestamp(photo.date).strftime("%Y-%m-%d_%H-%M-%S"),
                                 self.rnd_id()
                             )
+
+                            file_name = os.path.join(file_dir if file_dir is not None else '', file_name)
 
                         photo_loc = photo.sizes[-1].location
 
@@ -2614,6 +2618,7 @@ class Client:
     def download_media(self,
                        message: types.Message,
                        file_name: str = None,
+                       file_dir: str = 'downloads',
                        block: bool = True,
                        progress: callable = None):
         """Use this method to download the media from a Message.
@@ -2624,6 +2629,14 @@ class Client:
 
             file_name (:obj:`str`, optional):
                 Specify a custom *file_name* to be used instead of the one provided by Telegram.
+                This parameter is expected to be a full file path to the location you want the
+                file to be placed. If not specified, the file will be put into the directory
+                specified by *file_dir* with a generated name.
+
+            file_dir (:obj:`str`, optional):
+                Specify a directory to place the file in if no *file_name* is specified.
+                If *file_dir* is *None*, the current working directory is used. The default
+                value is the "downloads" folder in the current working directory.
 
             block (:obj:`bool`, optional):
                 Blocks the code execution until the file has been downloaded.
@@ -2656,7 +2669,7 @@ class Client:
                 media = message
 
             if media is not None:
-                self.download_queue.put((media, file_name, done, progress, path))
+                self.download_queue.put((media, file_dir, file_name, done, progress, path))
             else:
                 return
 

--- a/pyrogram/client/client.py
+++ b/pyrogram/client/client.py
@@ -575,7 +575,7 @@ class Client:
                         )
 
                 if temp_file_path:
-                    final_file_path = re.sub("\\\\", "/", os.path.join(directory, file_name))
+                    final_file_path = os.path.abspath(re.sub("\\\\", "/", os.path.join(directory, file_name)))
                     os.makedirs(directory, exist_ok=True)
                     shutil.move(temp_file_path, final_file_path)
             except Exception as e:


### PR DESCRIPTION
These changes would allow **client.get_file** to write to a given file name or file like object directly
via a new **file_out** parameter.

**file_out** can be a string or file/file like object that implements at least **.write**.

The parameter is optional, and if not specified the old behavior of creating a file
in the current working directory with a generated **.temp** name is kept.

---

**client.download_media** is reworked to allow downloading files to specific locations instead
of only the downloads folder.  The function can still generate a file name for you the way it did prior if desired.

**client.download_media** would no longer make use of a temporary file, as it uses **client.get_files**
new ability to write directly to a file object.

the change in the behavior of **file_name** is breaking for things expecting files to always end up in the "downloads" folder under the current working directory.  And also for things expecting the **block** parameter to be next after **file_name**.

Below is a short test which gives an overview of how the usage would change, and some examples of how **client.download_media** could be used with the changes.

To try this code you can install the version over at:

```pip install git+https://github.com/EriHoss/pyrogram@flexible_media_downloads --upgrade```

```python
from pyrogram import Client
from pyrogram.api import types

# This test assumes that the bot user is sending a jpg photo, or jpg file attachment.
# It uses the sent photo or file in the message update to test the new behavior.

def update_handler(client, update, users, chats):

    if isinstance(update, (types.UpdateNewChannelMessage, types.UpdateNewMessage)):
        message = update.message
        
        if isinstance(message, types.Message) and client.get_me().user.id == message.from_id:
            
            # file_dir has also been added to "client.download_photo", which inherits the
            # behavior of "client.download_media"
            
            # download directly to "direct/test.jpg"
            # directory trees used in file_name are created for you if they do not exist
            client.download_media(message, file_name='direct/test.jpg')
            
            # download to "downloads" in the current directory (the default).
            # folder is created if it does not exist.
            # file has a generated name.
            client.download_media(message)

            # download to the current working directory with a generated name
            client.download_media(message, file_dir='.')
            
            # download to 'custom_dir/custom_dir2' in the current directory.
            # folder tree is created if it does not exist.
            # file has a generated name.
            client.download_media(message, file_dir='custom_dir/custom_dir2')
            
            try:
                # The two arguments cannot be used simultaneously
                client.download_media(message, file_name='test2', file_dir='bad')
            except ValueError:
                print('file_name and file_dir are mutually exclusive')

            # this works because "client.get_file" can now write to file objects, 
            # and "client.download_media" accounts for this.
            # This includes file like objects that only implement .write
            # "client.download_media" will not close the file for you, you must close
            # it since your in control of the file object
            with open('file_object.jpg', 'wb') as f:
                client.download_media(message, file_name=f)
            

            # Test writing to "fake" file objects

            class DummyFile:
                def __init__(self):
                    self._write_cnt = 0

                def write(self, data):
                    # Required
                    self._write_cnt += 1

                def flush(self):
                    # Optional, will be called if it exists
                    print("Write count {}".format(self._write_cnt))

            client.download_media(message, file_name=DummyFile())
            
            # Check if fileno gets used when implemented

            class WrappedFile:
                def __init__(self, filename):
                    self._f = open(filename, 'wb')

                def write(self, data):
                    # Required
                    self._f.write(data)

                def flush(self):
                    # Optional, will be called if it exists
                    self._f.flush()

                def fileno(self):
                   print('fileno called!')
                   return self._f.fileno()
                
                def __enter__(self):
                    return self
                    
                def __exit__(self, exception_type, exception_value, traceback):
                    self._f.close()
            
            with WrappedFile('wrapped_file.jpg') as f:
                client.download_media(message, file_name=f)


def main():
    client = Client("example")
    client.set_update_handler(update_handler)
    client.start()
    client.idle()


if __name__ == "__main__":
    main()
```