### PR TITLE
Make Client.signal_handler reentrant (avoid calling Client.stop() twice)

### DIFF
--- a/pyrogram/client/client.py
+++ b/pyrogram/client/client.py
@@ -810,7 +810,6 @@ class Client:
         log.debug("{} stopped".format(name))
 
     def signal_handler(self, *args):
-        self.stop()
         self.is_idle = False
 
     def idle(self, stop_signals: tuple = (SIGINT, SIGTERM, SIGABRT)):
@@ -829,6 +828,8 @@ class Client:
 
         while self.is_idle:
             time.sleep(1)
+
+        self.stop()
 
     def send(self, data: Object):
         """Use this method to send Raw Function queries.


### PR DESCRIPTION
I noticed a double call to Client.stop() when quickly mashing CTRL-C on the console with the client running.

This is because the signal handler can be called again while Client.stop() is in the middle of executing.

Calling Client.stop() twice causes an exception inside the signal handler if **self.is_started** has been set to **False** already.

The exception can't be handled and it prints to the console.

I think this might be a better way to stop the idle loop, it keeps Client.stop() from being called twice when multiple signals queue up.