### PR TITLE
Make sure started Session is always stopped upon exceptions in Client.get_file

### DIFF
--- a/pyrogram/client/client.py
+++ b/pyrogram/client/client.py
@@ -2696,13 +2696,17 @@ class Client:
             )
 
             session.start()
-
-            session.send(
-                functions.auth.ImportAuthorization(
-                    id=exported_auth.id,
-                    bytes=exported_auth.bytes
+            try:
+                session.send(
+                    functions.auth.ImportAuthorization(
+                        id=exported_auth.id,
+                        bytes=exported_auth.bytes
+                    )
                 )
-            )
+            except Exception as e:
+                session.stop()
+                raise e
+
         else:
             session = Session(
                 dc_id,


### PR DESCRIPTION
In reference to: https://github.com/pyrogram/pyrogram/issues/68

I see there is a TODO on this function but here is a fix.