### PR TITLE
Updated doc info about thumbnail's size.

### DIFF
--- a/pyrogram/client/methods/messages/send_animation.py
+++ b/pyrogram/client/methods/messages/send_animation.py
@@ -75,7 +75,7 @@ class SendAnimation(BaseClient):
             thumb (``str``, *optional*):
                 Thumbnail of the animation file sent.
                 The thumbnail should be in JPEG format and less than 200 KB in size.
-                A thumbnail's width and height should not exceed 90 pixels.
+                A sum of a thumbnail's width and height should not exceed 400 pixels.
                 Thumbnails can't be reused and can be only uploaded as a new file.
 
             disable_notification (``bool``, *optional*):

--- a/pyrogram/client/methods/messages/send_audio.py
+++ b/pyrogram/client/methods/messages/send_audio.py
@@ -77,7 +77,7 @@ class SendAudio(BaseClient):
             thumb (``str``, *optional*):
                 Thumbnail of the music file album cover.
                 The thumbnail should be in JPEG format and less than 200 KB in size.
-                A thumbnail's width and height should not exceed 90 pixels.
+                A sum of a thumbnail's width and height should not exceed 400 pixels.
                 Thumbnails can't be reused and can be only uploaded as a new file.
 
             disable_notification (``bool``, *optional*):

--- a/pyrogram/client/methods/messages/send_document.py
+++ b/pyrogram/client/methods/messages/send_document.py
@@ -55,7 +55,7 @@ class SendDocument(BaseClient):
             thumb (``str``):
                 Thumbnail of the file sent.
                 The thumbnail should be in JPEG format and less than 200 KB in size.
-                A thumbnail's width and height should not exceed 90 pixels.
+                A sum of a thumbnail's width and height should not exceed 400 pixels.
                 Thumbnails can't be reused and can be only uploaded as a new file.
 
             caption (``str``, *optional*):

--- a/pyrogram/client/methods/messages/send_video.py
+++ b/pyrogram/client/methods/messages/send_video.py
@@ -76,7 +76,7 @@ class SendVideo(BaseClient):
             thumb (``str``, *optional*):
                 Thumbnail of the video sent.
                 The thumbnail should be in JPEG format and less than 200 KB in size.
-                A thumbnail's width and height should not exceed 90 pixels.
+                A sum of a thumbnail's width and height should not exceed 400 pixels.
                 Thumbnails can't be reused and can be only uploaded as a new file.
 
             supports_streaming (``bool``, *optional*):

--- a/pyrogram/client/methods/messages/send_video_note.py
+++ b/pyrogram/client/methods/messages/send_video_note.py
@@ -61,7 +61,7 @@ class SendVideoNote(BaseClient):
             thumb (``str``, *optional*):
                 Thumbnail of the video sent.
                 The thumbnail should be in JPEG format and less than 200 KB in size.
-                A thumbnail's width and height should not exceed 90 pixels.
+                A sum of a thumbnail's width and height should not exceed 400 pixels.
                 Thumbnails can't be reused and can be only uploaded as a new file.
 
             disable_notification (``bool``, *optional*):

--- a/pyrogram/client/types/input_media/input_media_animation.py
+++ b/pyrogram/client/types/input_media/input_media_animation.py
@@ -31,7 +31,7 @@ class InputMediaAnimation(InputMedia):
         thumb (``str``, *optional*):
             Thumbnail of the animation file sent.
             The thumbnail should be in JPEG format and less than 200 KB in size.
-            A thumbnail's width and height should not exceed 90 pixels.
+            A sum of a thumbnail's width and height should not exceed 400 pixels.
             Thumbnails can't be reused and can be only uploaded as a new file.
 
         caption (``str``, *optional*):

--- a/pyrogram/client/types/input_media/input_media_audio.py
+++ b/pyrogram/client/types/input_media/input_media_audio.py
@@ -32,7 +32,7 @@ class InputMediaAudio(InputMedia):
         thumb (``str``, *optional*):
             Thumbnail of the music file album cover.
             The thumbnail should be in JPEG format and less than 200 KB in size.
-            A thumbnail's width and height should not exceed 90 pixels.
+            A sum of a thumbnail's width and height should not exceed 400 pixels.
             Thumbnails can't be reused and can be only uploaded as a new file.
 
         caption (``str``, *optional*):

--- a/pyrogram/client/types/input_media/input_media_document.py
+++ b/pyrogram/client/types/input_media/input_media_document.py
@@ -31,7 +31,7 @@ class InputMediaDocument(InputMedia):
         thumb (``str``):
             Thumbnail of the file sent.
             The thumbnail should be in JPEG format and less than 200 KB in size.
-            A thumbnail's width and height should not exceed 90 pixels.
+            A sum of a thumbnail's width and height should not exceed 400 pixels.
             Thumbnails can't be reused and can be only uploaded as a new file.
 
         caption (``str``, *optional*):

--- a/pyrogram/client/types/input_media/input_media_video.py
+++ b/pyrogram/client/types/input_media/input_media_video.py
@@ -33,7 +33,7 @@ class InputMediaVideo(InputMedia):
         thumb (``str``):
             Thumbnail of the video sent.
             The thumbnail should be in JPEG format and less than 200 KB in size.
-            A thumbnail's width and height should not exceed 90 pixels.
+            A sum of a thumbnail's width and height should not exceed 400 pixels.
             Thumbnails can't be reused and can be only uploaded as a new file.
 
         caption (``str``, *optional*):


### PR DESCRIPTION
I noticed again that the documentation still says about the 90 pixel limit.
After six months of testing, I can say that the formula `width + height <= 400 pixels` works perfectly for thumbnails.
I don't see any reason to mislead users with wrong limitation.