### PR TITLE
Type hints

### DIFF
--- a/pyrogram/client/client.py
+++ b/pyrogram/client/client.py
@@ -37,6 +37,7 @@ from importlib import import_module
 from pathlib import Path
 from signal import signal, SIGINT, SIGTERM, SIGABRT
 from threading import Thread
+from typing import Union, List
 
 from pyrogram.api import functions, types
 from pyrogram.api.core import Object
@@ -152,7 +153,7 @@ class Client(Methods, BaseClient):
 
     def __init__(self,
                  session_name: str,
-                 api_id: int or str = None,
+                 api_id: Union[int, str] = None,
                  api_hash: str = None,
                  app_version: str = None,
                  device_model: str = None,
@@ -162,7 +163,7 @@ class Client(Methods, BaseClient):
                  proxy: dict = None,
                  test_mode: bool = False,
                  phone_number: str = None,
-                 phone_code: str or callable = None,
+                 phone_code: Union[str, callable] = None,
                  password: str = None,
                  force_sms: bool = False,
                  first_name: str = None,
@@ -367,7 +368,7 @@ class Client(Methods, BaseClient):
         self.start()
         self.idle()
 
-    def add_handler(self, handler, group: int = 0):
+    def add_handler(self, handler: Handler, group: int = 0):
         """Use this method to register an update handler.
 
         You can register multiple handlers, but at most one handler within a group
@@ -391,7 +392,7 @@ class Client(Methods, BaseClient):
 
         return handler, group
 
-    def remove_handler(self, handler, group: int = 0):
+    def remove_handler(self, handler: Handler, group: int = 0):
         """Removes a previously-added update handler.
 
         Make sure to provide the right group that the handler was added in. You can use
@@ -624,7 +625,9 @@ class Client(Methods, BaseClient):
 
         print("Logged in successfully as {}".format(r.user.first_name))
 
-    def fetch_peers(self, entities: list):
+    def fetch_peers(self, entities: List[Union[types.User,
+                                               types.Chat, types.ChatForbidden,
+                                               types.Channel, types.ChannelForbidden]]):
         for entity in entities:
             if isinstance(entity, types.User):
                 user_id = entity.id
@@ -886,7 +889,10 @@ class Client(Methods, BaseClient):
 
         log.debug("{} stopped".format(name))
 
-    def send(self, data: Object, retries: int = Session.MAX_RETRIES, timeout: float = Session.WAIT_TIMEOUT):
+    def send(self,
+             data: Object,
+             retries: int = Session.MAX_RETRIES,
+             timeout: float = Session.WAIT_TIMEOUT):
         """Use this method to send Raw Function queries.
 
         This method makes possible to manually call every single Telegram API method in a low-level manner.
@@ -1045,7 +1051,8 @@ class Client(Methods, BaseClient):
                 indent=4
             )
 
-    def get_initial_dialogs_chunk(self, offset_date: int = 0):
+    def get_initial_dialogs_chunk(self,
+                                  offset_date: int = 0):
         while True:
             try:
                 r = self.send(
@@ -1077,7 +1084,8 @@ class Client(Methods, BaseClient):
 
         self.get_initial_dialogs_chunk()
 
-    def resolve_peer(self, peer_id: int or str):
+    def resolve_peer(self,
+                     peer_id: Union[int, str]):
         """Use this method to get the InputPeer of a known peer_id.
 
         This is a utility method intended to be used only when working with Raw Functions (i.e: a Telegram API method

--- a/pyrogram/client/dispatcher/dispatcher.py
+++ b/pyrogram/client/dispatcher/dispatcher.py
@@ -62,17 +62,17 @@ class Dispatcher:
 
         self.update_parsers = {
             Dispatcher.MESSAGE_UPDATES:
-                lambda upd, usr, cht: (pyrogram.Message.parse(self.client, upd.message, usr, cht), MessageHandler),
+                lambda upd, usr, cht: (pyrogram.Message._parse(self.client, upd.message, usr, cht), MessageHandler),
 
             Dispatcher.DELETE_MESSAGES_UPDATES:
-                lambda upd, usr, cht: (pyrogram.Messages.parse_deleted(self.client, upd), DeletedMessagesHandler),
+                lambda upd, usr, cht: (pyrogram.Messages._parse_deleted(self.client, upd), DeletedMessagesHandler),
 
             Dispatcher.CALLBACK_QUERY_UPDATES:
-                lambda upd, usr, cht: (pyrogram.CallbackQuery.parse(self.client, upd, usr), CallbackQueryHandler),
+                lambda upd, usr, cht: (pyrogram.CallbackQuery._parse(self.client, upd, usr), CallbackQueryHandler),
 
             (types.UpdateUserStatus,):
                 lambda upd, usr, cht: (
-                    pyrogram.UserStatus.parse(self.client, upd.status, upd.user_id), UserStatusHandler
+                    pyrogram.UserStatus._parse(self.client, upd.status, upd.user_id), UserStatusHandler
                 )
         }
 

--- a/pyrogram/client/methods/bots/get_inline_bot_results.py
+++ b/pyrogram/client/methods/bots/get_inline_bot_results.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import Union
+
 from pyrogram.api import functions, types
 from pyrogram.api.errors import UnknownError
 from pyrogram.client.ext import BaseClient
@@ -23,7 +25,7 @@ from pyrogram.client.ext import BaseClient
 
 class GetInlineBotResults(BaseClient):
     def get_inline_bot_results(self,
-                               bot: int or str,
+                               bot: Union[int, str],
                                query: str,
                                offset: str = "",
                                latitude: float = None,

--- a/pyrogram/client/methods/bots/request_callback_answer.py
+++ b/pyrogram/client/methods/bots/request_callback_answer.py
@@ -16,13 +16,15 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import Union
+
 from pyrogram.api import functions
 from pyrogram.client.ext import BaseClient
 
 
 class RequestCallbackAnswer(BaseClient):
     def request_callback_answer(self,
-                                chat_id: int or str,
+                                chat_id: Union[int, str],
                                 message_id: int,
                                 callback_data: bytes):
         """Use this method to request a callback answer from bots. This is the equivalent of clicking an

--- a/pyrogram/client/methods/bots/send_inline_bot_result.py
+++ b/pyrogram/client/methods/bots/send_inline_bot_result.py
@@ -16,13 +16,15 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import Union
+
 from pyrogram.api import functions
 from pyrogram.client.ext import BaseClient
 
 
 class SendInlineBotResult(BaseClient):
     def send_inline_bot_result(self,
-                               chat_id: int or str,
+                               chat_id: Union[int, str],
                                query_id: int,
                                result_id: str,
                                disable_notification: bool = None,

--- a/pyrogram/client/methods/chats/delete_chat_photo.py
+++ b/pyrogram/client/methods/chats/delete_chat_photo.py
@@ -24,7 +24,7 @@ from ...ext import BaseClient
 
 class DeleteChatPhoto(BaseClient):
     def delete_chat_photo(self,
-                          chat_id: Union[int, str]):
+                          chat_id: Union[int, str]) -> bool:
         """Use this method to delete a chat photo.
         Photos can't be changed for private chats.
         You must be an administrator in the chat for this to work and must have the appropriate admin rights.

--- a/pyrogram/client/methods/chats/delete_chat_photo.py
+++ b/pyrogram/client/methods/chats/delete_chat_photo.py
@@ -16,12 +16,15 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import Union
+
 from pyrogram.api import functions, types
 from ...ext import BaseClient
 
 
 class DeleteChatPhoto(BaseClient):
-    def delete_chat_photo(self, chat_id: int or str):
+    def delete_chat_photo(self,
+                          chat_id: Union[int, str]):
         """Use this method to delete a chat photo.
         Photos can't be changed for private chats.
         You must be an administrator in the chat for this to work and must have the appropriate admin rights.

--- a/pyrogram/client/methods/chats/export_chat_invite_link.py
+++ b/pyrogram/client/methods/chats/export_chat_invite_link.py
@@ -24,7 +24,7 @@ from ...ext import BaseClient
 
 class ExportChatInviteLink(BaseClient):
     def export_chat_invite_link(self,
-                                chat_id: Union[int, str]):
+                                chat_id: Union[int, str]) -> str:
         """Use this method to generate a new invite link for a chat; any previously generated link is revoked.
 
         You must be an administrator in the chat for this to work and have the appropriate admin rights.

--- a/pyrogram/client/methods/chats/export_chat_invite_link.py
+++ b/pyrogram/client/methods/chats/export_chat_invite_link.py
@@ -16,12 +16,15 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import Union
+
 from pyrogram.api import functions, types
 from ...ext import BaseClient
 
 
 class ExportChatInviteLink(BaseClient):
-    def export_chat_invite_link(self, chat_id: int or str):
+    def export_chat_invite_link(self,
+                                chat_id: Union[int, str]):
         """Use this method to generate a new invite link for a chat; any previously generated link is revoked.
 
         You must be an administrator in the chat for this to work and have the appropriate admin rights.

--- a/pyrogram/client/methods/chats/get_chat.py
+++ b/pyrogram/client/methods/chats/get_chat.py
@@ -25,7 +25,7 @@ from ...ext import BaseClient
 
 class GetChat(BaseClient):
     def get_chat(self,
-                 chat_id: Union[int, str]):
+                 chat_id: Union[int, str]) -> "pyrogram.Chat":
         """Use this method to get up to date information about the chat (current name of the user for
         one-on-one conversations, current username of a user, group or channel, etc.)
 

--- a/pyrogram/client/methods/chats/get_chat.py
+++ b/pyrogram/client/methods/chats/get_chat.py
@@ -16,13 +16,16 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import Union
+
 import pyrogram
 from pyrogram.api import functions, types
 from ...ext import BaseClient
 
 
 class GetChat(BaseClient):
-    def get_chat(self, chat_id: int or str):
+    def get_chat(self,
+                 chat_id: Union[int, str]):
         """Use this method to get up to date information about the chat (current name of the user for
         one-on-one conversations, current username of a user, group or channel, etc.)
 
@@ -45,4 +48,4 @@ class GetChat(BaseClient):
         else:
             r = self.send(functions.messages.GetFullChat(peer.chat_id))
 
-        return pyrogram.Chat.parse_full(self, r)
+        return pyrogram.Chat._parse_full(self, r)

--- a/pyrogram/client/methods/chats/get_chat_member.py
+++ b/pyrogram/client/methods/chats/get_chat_member.py
@@ -26,7 +26,7 @@ from ...ext import BaseClient
 class GetChatMember(BaseClient):
     def get_chat_member(self,
                         chat_id: Union[int, str],
-                        user_id: Union[int, str]):
+                        user_id: Union[int, str]) -> "pyrogram.ChatMember":
         """Use this method to get information about one member of a chat.
 
         Args:
@@ -67,13 +67,6 @@ class GetChatMember(BaseClient):
                 )
             )
 
-            return pyrogram.ChatMembers._parse(
-                self,
-                types.channels.ChannelParticipants(
-                    count=1,
-                    participants=[r.participant],
-                    users=r.users
-                )
-            ).chat_members[0]
+            return pyrogram.ChatMember._parse(self, r.participant, r.users[0])
         else:
             raise ValueError("The chat_id \"{}\" belongs to a user".format(chat_id))

--- a/pyrogram/client/methods/chats/get_chat_member.py
+++ b/pyrogram/client/methods/chats/get_chat_member.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import Union
+
 import pyrogram
 from pyrogram.api import functions, types, errors
 from ...ext import BaseClient
@@ -23,8 +25,8 @@ from ...ext import BaseClient
 
 class GetChatMember(BaseClient):
     def get_chat_member(self,
-                        chat_id: int or str,
-                        user_id: int or str):
+                        chat_id: Union[int, str],
+                        user_id: Union[int, str]):
         """Use this method to get information about one member of a chat.
 
         Args:
@@ -52,7 +54,7 @@ class GetChatMember(BaseClient):
                 )
             )
 
-            for member in pyrogram.ChatMembers.parse(self, full_chat).chat_members:
+            for member in pyrogram.ChatMembers._parse(self, full_chat).chat_members:
                 if member.user.id == user_id.user_id:
                     return member
             else:
@@ -65,7 +67,7 @@ class GetChatMember(BaseClient):
                 )
             )
 
-            return pyrogram.ChatMembers.parse(
+            return pyrogram.ChatMembers._parse(
                 self,
                 types.channels.ChannelParticipants(
                     count=1,

--- a/pyrogram/client/methods/chats/get_chat_members.py
+++ b/pyrogram/client/methods/chats/get_chat_members.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import Union
+
 import pyrogram
 from pyrogram.api import functions, types
 from ...ext import BaseClient
@@ -32,7 +34,7 @@ class Filters:
 
 class GetChatMembers(BaseClient):
     def get_chat_members(self,
-                         chat_id: int or str,
+                         chat_id: Union[int, str],
                          offset: int = 0,
                          limit: int = 200,
                          query: str = "",
@@ -84,7 +86,7 @@ class GetChatMembers(BaseClient):
         peer = self.resolve_peer(chat_id)
 
         if isinstance(peer, types.InputPeerChat):
-            return pyrogram.ChatMembers.parse(
+            return pyrogram.ChatMembers._parse(
                 self,
                 self.send(
                     functions.messages.GetFullChat(
@@ -110,7 +112,7 @@ class GetChatMembers(BaseClient):
             else:
                 raise ValueError("Invalid filter \"{}\"".format(filter))
 
-            return pyrogram.ChatMembers.parse(
+            return pyrogram.ChatMembers._parse(
                 self,
                 self.send(
                     functions.channels.GetParticipants(

--- a/pyrogram/client/methods/chats/get_chat_members.py
+++ b/pyrogram/client/methods/chats/get_chat_members.py
@@ -38,7 +38,7 @@ class GetChatMembers(BaseClient):
                          offset: int = 0,
                          limit: int = 200,
                          query: str = "",
-                         filter: str = Filters.ALL):
+                         filter: str = Filters.ALL) -> "pyrogram.ChatMembers":
         """Use this method to get the members list of a chat.
 
         A chat can be either a basic group, a supergroup or a channel.

--- a/pyrogram/client/methods/chats/get_chat_members_count.py
+++ b/pyrogram/client/methods/chats/get_chat_members_count.py
@@ -24,7 +24,7 @@ from ...ext import BaseClient
 
 class GetChatMembersCount(BaseClient):
     def get_chat_members_count(self,
-                               chat_id: Union[int, str]):
+                               chat_id: Union[int, str]) -> int:
         """Use this method to get the number of members in a chat.
 
         Args:

--- a/pyrogram/client/methods/chats/get_chat_members_count.py
+++ b/pyrogram/client/methods/chats/get_chat_members_count.py
@@ -16,12 +16,15 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import Union
+
 from pyrogram.api import functions, types
 from ...ext import BaseClient
 
 
 class GetChatMembersCount(BaseClient):
-    def get_chat_members_count(self, chat_id: int or str):
+    def get_chat_members_count(self,
+                               chat_id: Union[int, str]):
         """Use this method to get the number of members in a chat.
 
         Args:

--- a/pyrogram/client/methods/chats/get_dialogs.py
+++ b/pyrogram/client/methods/chats/get_dialogs.py
@@ -23,7 +23,7 @@ from ...ext import BaseClient
 
 class GetDialogs(BaseClient):
     def get_dialogs(self,
-                    offset_dialog=None,
+                    offset_dialog: "pyrogram.Dialog" = None,
                     limit: int = 100,
                     pinned_only: bool = False):
         """Use this method to get the user's dialogs
@@ -64,4 +64,4 @@ class GetDialogs(BaseClient):
                 )
             )
 
-        return pyrogram.Dialogs.parse(self, r)
+        return pyrogram.Dialogs._parse(self, r)

--- a/pyrogram/client/methods/chats/get_dialogs.py
+++ b/pyrogram/client/methods/chats/get_dialogs.py
@@ -25,7 +25,7 @@ class GetDialogs(BaseClient):
     def get_dialogs(self,
                     offset_dialog: "pyrogram.Dialog" = None,
                     limit: int = 100,
-                    pinned_only: bool = False):
+                    pinned_only: bool = False) -> "pyrogram.Dialogs":
         """Use this method to get the user's dialogs
 
         You can get up to 100 dialogs at once.

--- a/pyrogram/client/methods/chats/join_chat.py
+++ b/pyrogram/client/methods/chats/join_chat.py
@@ -21,7 +21,8 @@ from ...ext import BaseClient
 
 
 class JoinChat(BaseClient):
-    def join_chat(self, chat_id: str):
+    def join_chat(self,
+                  chat_id: str):
         """Use this method to join a group chat or channel.
 
         Args:

--- a/pyrogram/client/methods/chats/kick_chat_member.py
+++ b/pyrogram/client/methods/chats/kick_chat_member.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import Union
+
 import pyrogram
 from pyrogram.api import functions, types
 from ...ext import BaseClient
@@ -23,8 +25,8 @@ from ...ext import BaseClient
 
 class KickChatMember(BaseClient):
     def kick_chat_member(self,
-                         chat_id: int or str,
-                         user_id: int or str,
+                         chat_id: Union[int, str],
+                         user_id: Union[int, str],
                          until_date: int = 0):
         """Use this method to kick a user from a group, a supergroup or a channel.
         In the case of supergroups and channels, the user will not be able to return to the group on their own using
@@ -86,7 +88,7 @@ class KickChatMember(BaseClient):
 
         for i in r.updates:
             if isinstance(i, (types.UpdateNewMessage, types.UpdateNewChannelMessage)):
-                return pyrogram.Message.parse(
+                return pyrogram.Message._parse(
                     self, i.message,
                     {i.id: i for i in r.users},
                     {i.id: i for i in r.chats}

--- a/pyrogram/client/methods/chats/kick_chat_member.py
+++ b/pyrogram/client/methods/chats/kick_chat_member.py
@@ -27,7 +27,7 @@ class KickChatMember(BaseClient):
     def kick_chat_member(self,
                          chat_id: Union[int, str],
                          user_id: Union[int, str],
-                         until_date: int = 0):
+                         until_date: int = 0) -> "pyrogram.Message":
         """Use this method to kick a user from a group, a supergroup or a channel.
         In the case of supergroups and channels, the user will not be able to return to the group on their own using
         invite links, etc., unless unbanned first. You must be an administrator in the chat for this to work and must

--- a/pyrogram/client/methods/chats/leave_chat.py
+++ b/pyrogram/client/methods/chats/leave_chat.py
@@ -16,12 +16,16 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import Union
+
 from pyrogram.api import functions, types
 from ...ext import BaseClient
 
 
 class LeaveChat(BaseClient):
-    def leave_chat(self, chat_id: int or str, delete: bool = False):
+    def leave_chat(self,
+                   chat_id: Union[int, str],
+                   delete: bool = False):
         """Use this method to leave a group chat or channel.
 
         Args:

--- a/pyrogram/client/methods/chats/pin_chat_message.py
+++ b/pyrogram/client/methods/chats/pin_chat_message.py
@@ -16,12 +16,17 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import Union
+
 from pyrogram.api import functions, types
 from ...ext import BaseClient
 
 
 class PinChatMessage(BaseClient):
-    def pin_chat_message(self, chat_id: int or str, message_id: int, disable_notification: bool = None):
+    def pin_chat_message(self,
+                         chat_id: Union[int, str],
+                         message_id: int,
+                         disable_notification: bool = None):
         """Use this method to pin a message in a supergroup or a channel.
         You must be an administrator in the chat for this to work and must have the "can_pin_messages" admin right in
         the supergroup or "can_edit_messages" admin right in the channel.

--- a/pyrogram/client/methods/chats/pin_chat_message.py
+++ b/pyrogram/client/methods/chats/pin_chat_message.py
@@ -26,7 +26,7 @@ class PinChatMessage(BaseClient):
     def pin_chat_message(self,
                          chat_id: Union[int, str],
                          message_id: int,
-                         disable_notification: bool = None):
+                         disable_notification: bool = None) -> bool:
         """Use this method to pin a message in a supergroup or a channel.
         You must be an administrator in the chat for this to work and must have the "can_pin_messages" admin right in
         the supergroup or "can_edit_messages" admin right in the channel.

--- a/pyrogram/client/methods/chats/promote_chat_member.py
+++ b/pyrogram/client/methods/chats/promote_chat_member.py
@@ -16,14 +16,16 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import Union
+
 from pyrogram.api import functions, types
 from ...ext import BaseClient
 
 
 class PromoteChatMember(BaseClient):
     def promote_chat_member(self,
-                            chat_id: int or str,
-                            user_id: int or str,
+                            chat_id: Union[int, str],
+                            user_id: Union[int, str],
                             can_change_info: bool = True,
                             can_post_messages: bool = False,
                             can_edit_messages: bool = False,

--- a/pyrogram/client/methods/chats/promote_chat_member.py
+++ b/pyrogram/client/methods/chats/promote_chat_member.py
@@ -33,7 +33,7 @@ class PromoteChatMember(BaseClient):
                             can_invite_users: bool = True,
                             can_restrict_members: bool = True,
                             can_pin_messages: bool = False,
-                            can_promote_members: bool = False):
+                            can_promote_members: bool = False) -> bool:
         """Use this method to promote or demote a user in a supergroup or a channel.
         You must be an administrator in the chat for this to work and must have the appropriate admin rights.
         Pass False for all boolean parameters to demote a user.

--- a/pyrogram/client/methods/chats/restrict_chat_member.py
+++ b/pyrogram/client/methods/chats/restrict_chat_member.py
@@ -16,14 +16,16 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import Union
+
 from pyrogram.api import functions, types
 from ...ext import BaseClient
 
 
 class RestrictChatMember(BaseClient):
     def restrict_chat_member(self,
-                             chat_id: int or str,
-                             user_id: int or str,
+                             chat_id: Union[int, str],
+                             user_id: Union[int, str],
                              until_date: int = 0,
                              can_send_messages: bool = False,
                              can_send_media_messages: bool = False,

--- a/pyrogram/client/methods/chats/restrict_chat_member.py
+++ b/pyrogram/client/methods/chats/restrict_chat_member.py
@@ -30,7 +30,7 @@ class RestrictChatMember(BaseClient):
                              can_send_messages: bool = False,
                              can_send_media_messages: bool = False,
                              can_send_other_messages: bool = False,
-                             can_add_web_page_previews: bool = False):
+                             can_add_web_page_previews: bool = False) -> bool:
         """Use this method to restrict a user in a supergroup. The bot must be an administrator in the supergroup for
         this to work and must have the appropriate admin rights. Pass True for all boolean parameters to lift
         restrictions from a user.

--- a/pyrogram/client/methods/chats/set_chat_description.py
+++ b/pyrogram/client/methods/chats/set_chat_description.py
@@ -16,12 +16,16 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import Union
+
 from pyrogram.api import functions, types
 from ...ext import BaseClient
 
 
 class SetChatDescription(BaseClient):
-    def set_chat_description(self, chat_id: int or str, description: str):
+    def set_chat_description(self,
+                             chat_id: Union[int, str],
+                             description: str):
         """Use this method to change the description of a supergroup or a channel.
         You must be an administrator in the chat for this to work and must have the appropriate admin rights.
 

--- a/pyrogram/client/methods/chats/set_chat_description.py
+++ b/pyrogram/client/methods/chats/set_chat_description.py
@@ -25,7 +25,7 @@ from ...ext import BaseClient
 class SetChatDescription(BaseClient):
     def set_chat_description(self,
                              chat_id: Union[int, str],
-                             description: str):
+                             description: str) -> bool:
         """Use this method to change the description of a supergroup or a channel.
         You must be an administrator in the chat for this to work and must have the appropriate admin rights.
 

--- a/pyrogram/client/methods/chats/set_chat_photo.py
+++ b/pyrogram/client/methods/chats/set_chat_photo.py
@@ -19,13 +19,16 @@
 import os
 from base64 import b64decode
 from struct import unpack
+from typing import Union
 
 from pyrogram.api import functions, types
 from ...ext import BaseClient
 
 
 class SetChatPhoto(BaseClient):
-    def set_chat_photo(self, chat_id: int or str, photo: str):
+    def set_chat_photo(self,
+                       chat_id: Union[int, str],
+                       photo: str):
         """Use this method to set a new profile photo for the chat.
         Photos can't be changed for private chats.
         You must be an administrator in the chat for this to work and must have the appropriate admin rights.

--- a/pyrogram/client/methods/chats/set_chat_photo.py
+++ b/pyrogram/client/methods/chats/set_chat_photo.py
@@ -28,7 +28,7 @@ from ...ext import BaseClient
 class SetChatPhoto(BaseClient):
     def set_chat_photo(self,
                        chat_id: Union[int, str],
-                       photo: str):
+                       photo: str) -> bool:
         """Use this method to set a new profile photo for the chat.
         Photos can't be changed for private chats.
         You must be an administrator in the chat for this to work and must have the appropriate admin rights.

--- a/pyrogram/client/methods/chats/set_chat_title.py
+++ b/pyrogram/client/methods/chats/set_chat_title.py
@@ -16,12 +16,16 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import Union
+
 from pyrogram.api import functions, types
 from ...ext import BaseClient
 
 
 class SetChatTitle(BaseClient):
-    def set_chat_title(self, chat_id: int or str, title: str):
+    def set_chat_title(self,
+                       chat_id: Union[int, str],
+                       title: str):
         """Use this method to change the title of a chat.
         Titles can't be changed for private chats.
         You must be an administrator in the chat for this to work and must have the appropriate admin rights.

--- a/pyrogram/client/methods/chats/set_chat_title.py
+++ b/pyrogram/client/methods/chats/set_chat_title.py
@@ -25,7 +25,7 @@ from ...ext import BaseClient
 class SetChatTitle(BaseClient):
     def set_chat_title(self,
                        chat_id: Union[int, str],
-                       title: str):
+                       title: str) -> bool:
         """Use this method to change the title of a chat.
         Titles can't be changed for private chats.
         You must be an administrator in the chat for this to work and must have the appropriate admin rights.

--- a/pyrogram/client/methods/chats/unban_chat_member.py
+++ b/pyrogram/client/methods/chats/unban_chat_member.py
@@ -16,14 +16,16 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import Union
+
 from pyrogram.api import functions, types
 from ...ext import BaseClient
 
 
 class UnbanChatMember(BaseClient):
     def unban_chat_member(self,
-                          chat_id: int or str,
-                          user_id: int or str):
+                          chat_id: Union[int, str],
+                          user_id: Union[int, str]):
         """Use this method to unban a previously kicked user in a supergroup or channel.
         The user will **not** return to the group or channel automatically, but will be able to join via link, etc.
         You must be an administrator for this to work.

--- a/pyrogram/client/methods/chats/unban_chat_member.py
+++ b/pyrogram/client/methods/chats/unban_chat_member.py
@@ -25,7 +25,7 @@ from ...ext import BaseClient
 class UnbanChatMember(BaseClient):
     def unban_chat_member(self,
                           chat_id: Union[int, str],
-                          user_id: Union[int, str]):
+                          user_id: Union[int, str]) -> bool:
         """Use this method to unban a previously kicked user in a supergroup or channel.
         The user will **not** return to the group or channel automatically, but will be able to join via link, etc.
         You must be an administrator for this to work.

--- a/pyrogram/client/methods/chats/unpin_chat_message.py
+++ b/pyrogram/client/methods/chats/unpin_chat_message.py
@@ -16,12 +16,15 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import Union
+
 from pyrogram.api import functions, types
 from ...ext import BaseClient
 
 
 class UnpinChatMessage(BaseClient):
-    def unpin_chat_message(self, chat_id: int or str):
+    def unpin_chat_message(self,
+                           chat_id: Union[int, str]):
         """Use this method to unpin a message in a supergroup or a channel.
         You must be an administrator in the chat for this to work and must have the "can_pin_messages" admin
         right in the supergroup or "can_edit_messages" admin right in the channel.

--- a/pyrogram/client/methods/chats/unpin_chat_message.py
+++ b/pyrogram/client/methods/chats/unpin_chat_message.py
@@ -24,7 +24,7 @@ from ...ext import BaseClient
 
 class UnpinChatMessage(BaseClient):
     def unpin_chat_message(self,
-                           chat_id: Union[int, str]):
+                           chat_id: Union[int, str]) -> bool:
         """Use this method to unpin a message in a supergroup or a channel.
         You must be an administrator in the chat for this to work and must have the "can_pin_messages" admin
         right in the supergroup or "can_edit_messages" admin right in the channel.

--- a/pyrogram/client/methods/contacts/add_contacts.py
+++ b/pyrogram/client/methods/contacts/add_contacts.py
@@ -16,17 +16,21 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import List
+
+import pyrogram
 from pyrogram.api import functions
 from ...ext import BaseClient
 
 
 class AddContacts(BaseClient):
-    def add_contacts(self, contacts: list):
+    def add_contacts(self,
+                     contacts: List["pyrogram.InputPhoneContact"]):
         """Use this method to add contacts to your Telegram address book.
 
         Args:
-            contacts (``list``):
-                A list of :obj:`InputPhoneContact <pyrogram.InputPhoneContact>`
+            contacts (List of :obj:`InputPhoneContact <pyrogram.InputPhoneContact>`):
+                The contact list to be added
 
         Returns:
             On success, the added contacts are returned.

--- a/pyrogram/client/methods/contacts/delete_contacts.py
+++ b/pyrogram/client/methods/contacts/delete_contacts.py
@@ -16,17 +16,20 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import List
+
 from pyrogram.api import functions, types
 from pyrogram.api.errors import PeerIdInvalid
 from ...ext import BaseClient
 
 
 class DeleteContacts(BaseClient):
-    def delete_contacts(self, ids: list):
+    def delete_contacts(self,
+                        ids: List[int]):
         """Use this method to delete contacts from your Telegram address book
 
         Args:
-            ids (``list``):
+            ids (List of ``int``):
                 A list of unique identifiers for the target users.
                 Can be an ID (int), a username (string) or phone number (string).
 

--- a/pyrogram/client/methods/decorators/on_callback_query.py
+++ b/pyrogram/client/methods/decorators/on_callback_query.py
@@ -16,15 +16,18 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import Tuple
+
 import pyrogram
 from pyrogram.client.filters.filter import Filter
+from pyrogram.client.handlers.handler import Handler
 from ...ext import BaseClient
 
 
 class OnCallbackQuery(BaseClient):
     def on_callback_query(self=None,
                           filters=None,
-                          group: int = 0):
+                          group: int = 0) -> callable:
         """Use this decorator to automatically register a function for handling
         callback queries. This does the same thing as :meth:`add_handler` using the
         :class:`CallbackQueryHandler`.
@@ -45,7 +48,7 @@ class OnCallbackQuery(BaseClient):
                 The group identifier, defaults to 0.
         """
 
-        def decorator(func):
+        def decorator(func: callable) -> Tuple[Handler, int]:
             if isinstance(func, tuple):
                 func = func[0].callback
 

--- a/pyrogram/client/methods/decorators/on_callback_query.py
+++ b/pyrogram/client/methods/decorators/on_callback_query.py
@@ -22,7 +22,9 @@ from ...ext import BaseClient
 
 
 class OnCallbackQuery(BaseClient):
-    def on_callback_query(self=None, filters=None, group: int = 0):
+    def on_callback_query(self=None,
+                          filters=None,
+                          group: int = 0):
         """Use this decorator to automatically register a function for handling
         callback queries. This does the same thing as :meth:`add_handler` using the
         :class:`CallbackQueryHandler`.

--- a/pyrogram/client/methods/decorators/on_deleted_messages.py
+++ b/pyrogram/client/methods/decorators/on_deleted_messages.py
@@ -22,7 +22,9 @@ from ...ext import BaseClient
 
 
 class OnDeletedMessages(BaseClient):
-    def on_deleted_messages(self=None, filters=None, group: int = 0):
+    def on_deleted_messages(self=None,
+                            filters=None,
+                            group: int = 0):
         """Use this decorator to automatically register a function for handling
         deleted messages. This does the same thing as :meth:`add_handler` using the
         :class:`DeletedMessagesHandler`.

--- a/pyrogram/client/methods/decorators/on_deleted_messages.py
+++ b/pyrogram/client/methods/decorators/on_deleted_messages.py
@@ -16,15 +16,18 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import Tuple
+
 import pyrogram
 from pyrogram.client.filters.filter import Filter
+from pyrogram.client.handlers.handler import Handler
 from ...ext import BaseClient
 
 
 class OnDeletedMessages(BaseClient):
     def on_deleted_messages(self=None,
                             filters=None,
-                            group: int = 0):
+                            group: int = 0) -> callable:
         """Use this decorator to automatically register a function for handling
         deleted messages. This does the same thing as :meth:`add_handler` using the
         :class:`DeletedMessagesHandler`.
@@ -45,7 +48,7 @@ class OnDeletedMessages(BaseClient):
                 The group identifier, defaults to 0.
         """
 
-        def decorator(func):
+        def decorator(func: callable) -> Tuple[Handler, int]:
             if isinstance(func, tuple):
                 func = func[0].callback
 

--- a/pyrogram/client/methods/decorators/on_disconnect.py
+++ b/pyrogram/client/methods/decorators/on_disconnect.py
@@ -17,17 +17,18 @@
 # along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 import pyrogram
+from pyrogram.client.handlers.handler import Handler
 from ...ext import BaseClient
 
 
 class OnDisconnect(BaseClient):
-    def on_disconnect(self=None):
+    def on_disconnect(self=None) -> callable:
         """Use this decorator to automatically register a function for handling
         disconnections. This does the same thing as :meth:`add_handler` using the
         :class:`DisconnectHandler`.
         """
 
-        def decorator(func):
+        def decorator(func: callable) -> Handler:
             handler = pyrogram.DisconnectHandler(func)
 
             if self is not None:

--- a/pyrogram/client/methods/decorators/on_message.py
+++ b/pyrogram/client/methods/decorators/on_message.py
@@ -24,7 +24,7 @@ from ...ext import BaseClient
 class OnMessage(BaseClient):
     def on_message(self=None,
                    filters=None,
-                   group: int = 0):
+                   group: int = 0) -> callable:
         """Use this decorator to automatically register a function for handling
         messages. This does the same thing as :meth:`add_handler` using the
         :class:`MessageHandler`.

--- a/pyrogram/client/methods/decorators/on_message.py
+++ b/pyrogram/client/methods/decorators/on_message.py
@@ -22,7 +22,9 @@ from ...ext import BaseClient
 
 
 class OnMessage(BaseClient):
-    def on_message(self=None, filters=None, group: int = 0):
+    def on_message(self=None,
+                   filters=None,
+                   group: int = 0):
         """Use this decorator to automatically register a function for handling
         messages. This does the same thing as :meth:`add_handler` using the
         :class:`MessageHandler`.

--- a/pyrogram/client/methods/decorators/on_raw_update.py
+++ b/pyrogram/client/methods/decorators/on_raw_update.py
@@ -21,7 +21,8 @@ from ...ext import BaseClient
 
 
 class OnRawUpdate(BaseClient):
-    def on_raw_update(self=None, group: int = 0):
+    def on_raw_update(self=None,
+                      group: int = 0):
         """Use this decorator to automatically register a function for handling
         raw updates. This does the same thing as :meth:`add_handler` using the
         :class:`RawUpdateHandler`.

--- a/pyrogram/client/methods/decorators/on_raw_update.py
+++ b/pyrogram/client/methods/decorators/on_raw_update.py
@@ -16,13 +16,16 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import Tuple
+
 import pyrogram
+from pyrogram.client.handlers.handler import Handler
 from ...ext import BaseClient
 
 
 class OnRawUpdate(BaseClient):
     def on_raw_update(self=None,
-                      group: int = 0):
+                      group: int = 0) -> callable:
         """Use this decorator to automatically register a function for handling
         raw updates. This does the same thing as :meth:`add_handler` using the
         :class:`RawUpdateHandler`.
@@ -39,7 +42,7 @@ class OnRawUpdate(BaseClient):
                 The group identifier, defaults to 0.
         """
 
-        def decorator(func):
+        def decorator(func: callable) -> Tuple[Handler, int]:
             if isinstance(func, tuple):
                 func = func[0].callback
 

--- a/pyrogram/client/methods/decorators/on_user_status.py
+++ b/pyrogram/client/methods/decorators/on_user_status.py
@@ -16,15 +16,18 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import Tuple
+
 import pyrogram
 from pyrogram.client.filters.filter import Filter
+from pyrogram.client.handlers.handler import Handler
 from ...ext import BaseClient
 
 
 class OnUserStatus(BaseClient):
     def on_user_status(self=None,
                        filters=None,
-                       group: int = 0):
+                       group: int = 0) -> callable:
         """Use this decorator to automatically register a function for handling
         user status updates. This does the same thing as :meth:`add_handler` using the
         :class:`UserStatusHandler`.
@@ -44,7 +47,7 @@ class OnUserStatus(BaseClient):
                 The group identifier, defaults to 0.
         """
 
-        def decorator(func):
+        def decorator(func: callable) -> Tuple[Handler, int]:
             if isinstance(func, tuple):
                 func = func[0].callback
 

--- a/pyrogram/client/methods/decorators/on_user_status.py
+++ b/pyrogram/client/methods/decorators/on_user_status.py
@@ -22,7 +22,9 @@ from ...ext import BaseClient
 
 
 class OnUserStatus(BaseClient):
-    def on_user_status(self=None, filters=None, group: int = 0):
+    def on_user_status(self=None,
+                       filters=None,
+                       group: int = 0):
         """Use this decorator to automatically register a function for handling
         user status updates. This does the same thing as :meth:`add_handler` using the
         :class:`UserStatusHandler`.

--- a/pyrogram/client/methods/messages/delete_messages.py
+++ b/pyrogram/client/methods/messages/delete_messages.py
@@ -26,7 +26,7 @@ class DeleteMessages(BaseClient):
     def delete_messages(self,
                         chat_id: Union[int, str],
                         message_ids: Iterable[int],
-                        revoke: bool = True):
+                        revoke: bool = True) -> bool:
         """Use this method to delete messages, including service messages, with the following limitations:
 
         - A message can only be deleted if it was sent less than 48 hours ago.

--- a/pyrogram/client/methods/messages/delete_messages.py
+++ b/pyrogram/client/methods/messages/delete_messages.py
@@ -16,14 +16,16 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import Union, Iterable
+
 from pyrogram.api import functions, types
 from pyrogram.client.ext import BaseClient
 
 
 class DeleteMessages(BaseClient):
     def delete_messages(self,
-                        chat_id: int or str,
-                        message_ids,
+                        chat_id: Union[int, str],
+                        message_ids: Iterable[int],
                         revoke: bool = True):
         """Use this method to delete messages, including service messages, with the following limitations:
 

--- a/pyrogram/client/methods/messages/edit_message_caption.py
+++ b/pyrogram/client/methods/messages/edit_message_caption.py
@@ -29,7 +29,7 @@ class EditMessageCaption(BaseClient):
                              message_id: int,
                              caption: str,
                              parse_mode: str = "",
-                             reply_markup: "pyrogram.InlineKeyboardMarkup" = None):
+                             reply_markup: "pyrogram.InlineKeyboardMarkup" = None) -> "pyrogram.Message":
         """Use this method to edit captions of messages.
 
         Args:

--- a/pyrogram/client/methods/messages/edit_message_caption.py
+++ b/pyrogram/client/methods/messages/edit_message_caption.py
@@ -16,19 +16,20 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-import pyrogram
+from typing import Union
 
+import pyrogram
 from pyrogram.api import functions, types
 from pyrogram.client.ext import BaseClient
 
 
 class EditMessageCaption(BaseClient):
     def edit_message_caption(self,
-                             chat_id: int or str,
+                             chat_id: Union[int, str],
                              message_id: int,
                              caption: str,
                              parse_mode: str = "",
-                             reply_markup=None):
+                             reply_markup: "pyrogram.InlineKeyboardMarkup" = None):
         """Use this method to edit captions of messages.
 
         Args:
@@ -70,7 +71,7 @@ class EditMessageCaption(BaseClient):
 
         for i in r.updates:
             if isinstance(i, (types.UpdateEditMessage, types.UpdateEditChannelMessage)):
-                return pyrogram.Message.parse(
+                return pyrogram.Message._parse(
                     self, i.message,
                     {i.id: i for i in r.users},
                     {i.id: i for i in r.chats}

--- a/pyrogram/client/methods/messages/edit_message_media.py
+++ b/pyrogram/client/methods/messages/edit_message_media.py
@@ -20,6 +20,7 @@ import binascii
 import mimetypes
 import os
 import struct
+from typing import Union
 
 import pyrogram
 from pyrogram.api import functions, types
@@ -29,14 +30,15 @@ from pyrogram.client.types import (
     InputMediaPhoto, InputMediaVideo, InputMediaAudio,
     InputMediaAnimation, InputMediaDocument
 )
+from pyrogram.client.types.input_media import InputMedia
 
 
 class EditMessageMedia(BaseClient):
     def edit_message_media(self,
-                           chat_id: int or str,
+                           chat_id: Union[int, str],
                            message_id: int,
-                           media,
-                           reply_markup=None):
+                           media: InputMedia,
+                           reply_markup: "pyrogram.InlineKeyboardMarkup" = None):
         """Use this method to edit audio, document, photo, or video messages.
 
         If a message is a part of a message album, then it can be edited only to a photo or a video. Otherwise,
@@ -334,7 +336,7 @@ class EditMessageMedia(BaseClient):
 
         for i in r.updates:
             if isinstance(i, (types.UpdateEditMessage, types.UpdateEditChannelMessage)):
-                return pyrogram.Message.parse(
+                return pyrogram.Message._parse(
                     self, i.message,
                     {i.id: i for i in r.users},
                     {i.id: i for i in r.chats}

--- a/pyrogram/client/methods/messages/edit_message_media.py
+++ b/pyrogram/client/methods/messages/edit_message_media.py
@@ -38,7 +38,7 @@ class EditMessageMedia(BaseClient):
                            chat_id: Union[int, str],
                            message_id: int,
                            media: InputMedia,
-                           reply_markup: "pyrogram.InlineKeyboardMarkup" = None):
+                           reply_markup: "pyrogram.InlineKeyboardMarkup" = None) -> "pyrogram.Message":
         """Use this method to edit audio, document, photo, or video messages.
 
         If a message is a part of a message album, then it can be edited only to a photo or a video. Otherwise,

--- a/pyrogram/client/methods/messages/edit_message_reply_markup.py
+++ b/pyrogram/client/methods/messages/edit_message_reply_markup.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import Union
+
 import pyrogram
 from pyrogram.api import functions, types
 from pyrogram.client.ext import BaseClient
@@ -23,9 +25,9 @@ from pyrogram.client.ext import BaseClient
 
 class EditMessageReplyMarkup(BaseClient):
     def edit_message_reply_markup(self,
-                                  chat_id: int or str,
+                                  chat_id: Union[int, str],
                                   message_id: int,
-                                  reply_markup=None):
+                                  reply_markup: "pyrogram.InlineKeyboardMarkup" = None):
         """Use this method to edit only the reply markup of messages sent by the bot or via the bot (for inline bots).
 
         Args:
@@ -58,7 +60,7 @@ class EditMessageReplyMarkup(BaseClient):
 
         for i in r.updates:
             if isinstance(i, (types.UpdateEditMessage, types.UpdateEditChannelMessage)):
-                return pyrogram.Message.parse(
+                return pyrogram.Message._parse(
                     self, i.message,
                     {i.id: i for i in r.users},
                     {i.id: i for i in r.chats}

--- a/pyrogram/client/methods/messages/edit_message_reply_markup.py
+++ b/pyrogram/client/methods/messages/edit_message_reply_markup.py
@@ -27,7 +27,7 @@ class EditMessageReplyMarkup(BaseClient):
     def edit_message_reply_markup(self,
                                   chat_id: Union[int, str],
                                   message_id: int,
-                                  reply_markup: "pyrogram.InlineKeyboardMarkup" = None):
+                                  reply_markup: "pyrogram.InlineKeyboardMarkup" = None) -> "pyrogram.Message":
         """Use this method to edit only the reply markup of messages sent by the bot or via the bot (for inline bots).
 
         Args:

--- a/pyrogram/client/methods/messages/edit_message_text.py
+++ b/pyrogram/client/methods/messages/edit_message_text.py
@@ -30,7 +30,7 @@ class EditMessageText(BaseClient):
                           text: str,
                           parse_mode: str = "",
                           disable_web_page_preview: bool = None,
-                          reply_markup: "pyrogram.InlineKeyboardMarkup" = None):
+                          reply_markup: "pyrogram.InlineKeyboardMarkup" = None) -> "pyrogram.Message":
         """Use this method to edit text messages.
 
         Args:

--- a/pyrogram/client/methods/messages/edit_message_text.py
+++ b/pyrogram/client/methods/messages/edit_message_text.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import Union
+
 import pyrogram
 from pyrogram.api import functions, types
 from pyrogram.client.ext import BaseClient
@@ -23,12 +25,12 @@ from pyrogram.client.ext import BaseClient
 
 class EditMessageText(BaseClient):
     def edit_message_text(self,
-                          chat_id: int or str,
+                          chat_id: Union[int, str],
                           message_id: int,
                           text: str,
                           parse_mode: str = "",
                           disable_web_page_preview: bool = None,
-                          reply_markup=None):
+                          reply_markup: "pyrogram.InlineKeyboardMarkup" = None):
         """Use this method to edit text messages.
 
         Args:
@@ -74,7 +76,7 @@ class EditMessageText(BaseClient):
 
         for i in r.updates:
             if isinstance(i, (types.UpdateEditMessage, types.UpdateEditChannelMessage)):
-                return pyrogram.Message.parse(
+                return pyrogram.Message._parse(
                     self, i.message,
                     {i.id: i for i in r.users},
                     {i.id: i for i in r.chats}

--- a/pyrogram/client/methods/messages/forward_messages.py
+++ b/pyrogram/client/methods/messages/forward_messages.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import Union, Iterable
+
 import pyrogram
 from pyrogram.api import functions, types
 from ...ext import BaseClient
@@ -23,9 +25,9 @@ from ...ext import BaseClient
 
 class ForwardMessages(BaseClient):
     def forward_messages(self,
-                         chat_id: int or str,
-                         from_chat_id: int or str,
-                         message_ids,
+                         chat_id: Union[int, str],
+                         from_chat_id: Union[int, str],
+                         message_ids: Iterable[int],
                          disable_notification: bool = None):
         """Use this method to forward messages of any kind.
 
@@ -78,7 +80,7 @@ class ForwardMessages(BaseClient):
         for i in r.updates:
             if isinstance(i, (types.UpdateNewMessage, types.UpdateNewChannelMessage)):
                 messages.append(
-                    pyrogram.Message.parse(
+                    pyrogram.Message._parse(
                         self, i.message,
                         users, chats
                     )

--- a/pyrogram/client/methods/messages/forward_messages.py
+++ b/pyrogram/client/methods/messages/forward_messages.py
@@ -28,7 +28,7 @@ class ForwardMessages(BaseClient):
                          chat_id: Union[int, str],
                          from_chat_id: Union[int, str],
                          message_ids: Iterable[int],
-                         disable_notification: bool = None):
+                         disable_notification: bool = None) -> "pyrogram.Messages":
         """Use this method to forward messages of any kind.
 
         Args:
@@ -51,7 +51,7 @@ class ForwardMessages(BaseClient):
                 Users will receive a notification with no sound.
 
         Returns:
-            On success and in case *message_ids* was a list, the returned value will be a list of the forwarded
+            On success and in case *message_ids* was an iterable, the returned value will be a list of the forwarded
             :obj:`Messages <pyrogram.Message>` even if a list contains just one element, otherwise if
             *message_ids* was an integer, the single forwarded :obj:`Message <pyrogram.Message>`
             is returned.
@@ -86,4 +86,8 @@ class ForwardMessages(BaseClient):
                     )
                 )
 
-        return messages if is_iterable else messages[0]
+        return pyrogram.Messages(
+            client=self,
+            total_count=len(messages),
+            messages=messages
+        ) if is_iterable else messages[0]

--- a/pyrogram/client/methods/messages/get_history.py
+++ b/pyrogram/client/methods/messages/get_history.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import Union
+
 import pyrogram
 from pyrogram.api import functions
 from ...ext import BaseClient
@@ -23,7 +25,7 @@ from ...ext import BaseClient
 
 class GetHistory(BaseClient):
     def get_history(self,
-                    chat_id: int or str,
+                    chat_id: Union[int, str],
                     offset: int = 0,
                     limit: int = 100,
                     offset_id: int = 0,
@@ -59,7 +61,7 @@ class GetHistory(BaseClient):
             :class:`Error <pyrogram.Error>` in case of a Telegram RPC error.
         """
 
-        return pyrogram.Messages.parse(
+        return pyrogram.Messages._parse(
             self,
             self.send(
                 functions.messages.GetHistory(

--- a/pyrogram/client/methods/messages/get_messages.py
+++ b/pyrogram/client/methods/messages/get_messages.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import Union, Iterable
+
 import pyrogram
 from pyrogram.api import functions, types
 from ...ext import BaseClient
@@ -23,9 +25,9 @@ from ...ext import BaseClient
 
 class GetMessages(BaseClient):
     def get_messages(self,
-                     chat_id: int or str,
-                     message_ids: int or list = None,
-                     reply_to_message_ids: int or list = None,
+                     chat_id: Union[int, str],
+                     message_ids: Union[int, Iterable[int]] = None,
+                     reply_to_message_ids: Union[int, Iterable[int]] = None,
                      replies: int = 1):
         """Use this method to get one or more messages that belong to a specific chat.
         You can retrieve up to 200 messages at once.
@@ -76,6 +78,6 @@ class GetMessages(BaseClient):
         else:
             rpc = functions.messages.GetMessages(id=ids)
 
-        messages = pyrogram.Messages.parse(self, self.send(rpc))
+        messages = pyrogram.Messages._parse(self, self.send(rpc))
 
         return messages if is_iterable else messages.messages[0]

--- a/pyrogram/client/methods/messages/get_messages.py
+++ b/pyrogram/client/methods/messages/get_messages.py
@@ -28,7 +28,7 @@ class GetMessages(BaseClient):
                      chat_id: Union[int, str],
                      message_ids: Union[int, Iterable[int]] = None,
                      reply_to_message_ids: Union[int, Iterable[int]] = None,
-                     replies: int = 1):
+                     replies: int = 1) -> "pyrogram.Messages":
         """Use this method to get one or more messages that belong to a specific chat.
         You can retrieve up to 200 messages at once.
 

--- a/pyrogram/client/methods/messages/send_animation.py
+++ b/pyrogram/client/methods/messages/send_animation.py
@@ -20,6 +20,7 @@ import binascii
 import mimetypes
 import os
 import struct
+from typing import Union
 
 import pyrogram
 from pyrogram.api import functions, types
@@ -29,7 +30,7 @@ from pyrogram.client.ext import BaseClient, utils
 
 class SendAnimation(BaseClient):
     def send_animation(self,
-                       chat_id: int or str,
+                       chat_id: Union[int, str],
                        animation: str,
                        caption: str = "",
                        parse_mode: str = "",
@@ -39,7 +40,10 @@ class SendAnimation(BaseClient):
                        thumb: str = None,
                        disable_notification: bool = None,
                        reply_to_message_id: int = None,
-                       reply_markup=None,
+                       reply_markup: Union["pyrogram.InlineKeyboardMarkup",
+                                           "pyrogram.ReplyKeyboardMarkup",
+                                           "pyrogram.ReplyKeyboardRemove",
+                                           "pyrogram.ForceReply"] = None,
                        progress: callable = None,
                        progress_args: tuple = ()):
         """Use this method to send animation files (animation or H.264/MPEG-4 AVC video without sound).
@@ -185,7 +189,7 @@ class SendAnimation(BaseClient):
             else:
                 for i in r.updates:
                     if isinstance(i, (types.UpdateNewMessage, types.UpdateNewChannelMessage)):
-                        return pyrogram.Message.parse(
+                        return pyrogram.Message._parse(
                             self, i.message,
                             {i.id: i for i in r.users},
                             {i.id: i for i in r.chats}

--- a/pyrogram/client/methods/messages/send_animation.py
+++ b/pyrogram/client/methods/messages/send_animation.py
@@ -45,7 +45,7 @@ class SendAnimation(BaseClient):
                                            "pyrogram.ReplyKeyboardRemove",
                                            "pyrogram.ForceReply"] = None,
                        progress: callable = None,
-                       progress_args: tuple = ()):
+                       progress_args: tuple = ()) -> "pyrogram.Message":
         """Use this method to send animation files (animation or H.264/MPEG-4 AVC video without sound).
 
         Args:

--- a/pyrogram/client/methods/messages/send_audio.py
+++ b/pyrogram/client/methods/messages/send_audio.py
@@ -45,7 +45,7 @@ class SendAudio(BaseClient):
                                        "pyrogram.ReplyKeyboardRemove",
                                        "pyrogram.ForceReply"] = None,
                    progress: callable = None,
-                   progress_args: tuple = ()):
+                   progress_args: tuple = ()) -> "pyrogram.Message":
         """Use this method to send audio files.
 
         For sending voice messages, use the :obj:`send_voice()` method instead.

--- a/pyrogram/client/methods/messages/send_audio.py
+++ b/pyrogram/client/methods/messages/send_audio.py
@@ -20,6 +20,7 @@ import binascii
 import mimetypes
 import os
 import struct
+from typing import Union
 
 import pyrogram
 from pyrogram.api import functions, types
@@ -29,7 +30,7 @@ from pyrogram.client.ext import BaseClient, utils
 
 class SendAudio(BaseClient):
     def send_audio(self,
-                   chat_id: int or str,
+                   chat_id: Union[int, str],
                    audio: str,
                    caption: str = "",
                    parse_mode: str = "",
@@ -39,7 +40,10 @@ class SendAudio(BaseClient):
                    thumb: str = None,
                    disable_notification: bool = None,
                    reply_to_message_id: int = None,
-                   reply_markup=None,
+                   reply_markup: Union["pyrogram.InlineKeyboardMarkup",
+                                       "pyrogram.ReplyKeyboardMarkup",
+                                       "pyrogram.ReplyKeyboardRemove",
+                                       "pyrogram.ForceReply"] = None,
                    progress: callable = None,
                    progress_args: tuple = ()):
         """Use this method to send audio files.
@@ -185,7 +189,7 @@ class SendAudio(BaseClient):
             else:
                 for i in r.updates:
                     if isinstance(i, (types.UpdateNewMessage, types.UpdateNewChannelMessage)):
-                        return pyrogram.Message.parse(
+                        return pyrogram.Message._parse(
                             self, i.message,
                             {i.id: i for i in r.users},
                             {i.id: i for i in r.chats}

--- a/pyrogram/client/methods/messages/send_chat_action.py
+++ b/pyrogram/client/methods/messages/send_chat_action.py
@@ -16,14 +16,16 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import Union
+
 from pyrogram.api import functions
 from pyrogram.client.ext import BaseClient, ChatAction
 
 
 class SendChatAction(BaseClient):
     def send_chat_action(self,
-                         chat_id: int or str,
-                         action: ChatAction or str,
+                         chat_id: Union[int, str],
+                         action: Union[ChatAction, str],
                          progress: int = 0):
         """Use this method when you need to tell the other party that something is happening on your side.
 

--- a/pyrogram/client/methods/messages/send_contact.py
+++ b/pyrogram/client/methods/messages/send_contact.py
@@ -35,7 +35,7 @@ class SendContact(BaseClient):
                      reply_markup: Union["pyrogram.InlineKeyboardMarkup",
                                          "pyrogram.ReplyKeyboardMarkup",
                                          "pyrogram.ReplyKeyboardRemove",
-                                         "pyrogram.ForceReply"] = None):
+                                         "pyrogram.ForceReply"] = None) -> "pyrogram.Message":
         """Use this method to send phone contacts.
 
         Args:

--- a/pyrogram/client/methods/messages/send_contact.py
+++ b/pyrogram/client/methods/messages/send_contact.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import Union
+
 import pyrogram
 from pyrogram.api import functions, types
 from pyrogram.client.ext import BaseClient
@@ -23,14 +25,17 @@ from pyrogram.client.ext import BaseClient
 
 class SendContact(BaseClient):
     def send_contact(self,
-                     chat_id: int or str,
+                     chat_id: Union[int, str],
                      phone_number: str,
                      first_name: str,
                      last_name: str = "",
                      vcard: str = "",
                      disable_notification: bool = None,
                      reply_to_message_id: int = None,
-                     reply_markup=None):
+                     reply_markup: Union["pyrogram.InlineKeyboardMarkup",
+                                         "pyrogram.ReplyKeyboardMarkup",
+                                         "pyrogram.ReplyKeyboardRemove",
+                                         "pyrogram.ForceReply"] = None):
         """Use this method to send phone contacts.
 
         Args:
@@ -87,7 +92,7 @@ class SendContact(BaseClient):
 
         for i in r.updates:
             if isinstance(i, (types.UpdateNewMessage, types.UpdateNewChannelMessage)):
-                return pyrogram.Message.parse(
+                return pyrogram.Message._parse(
                     self, i.message,
                     {i.id: i for i in r.users},
                     {i.id: i for i in r.chats}

--- a/pyrogram/client/methods/messages/send_document.py
+++ b/pyrogram/client/methods/messages/send_document.py
@@ -20,6 +20,7 @@ import binascii
 import mimetypes
 import os
 import struct
+from typing import Union
 
 import pyrogram
 from pyrogram.api import functions, types
@@ -29,14 +30,17 @@ from pyrogram.client.ext import BaseClient, utils
 
 class SendDocument(BaseClient):
     def send_document(self,
-                      chat_id: int or str,
+                      chat_id: Union[int, str],
                       document: str,
                       thumb: str = None,
                       caption: str = "",
                       parse_mode: str = "",
                       disable_notification: bool = None,
                       reply_to_message_id: int = None,
-                      reply_markup=None,
+                      reply_markup: Union["pyrogram.InlineKeyboardMarkup",
+                                          "pyrogram.ReplyKeyboardMarkup",
+                                          "pyrogram.ReplyKeyboardRemove",
+                                          "pyrogram.ForceReply"] = None,
                       progress: callable = None,
                       progress_args: tuple = ()):
         """Use this method to send general files.
@@ -166,7 +170,7 @@ class SendDocument(BaseClient):
             else:
                 for i in r.updates:
                     if isinstance(i, (types.UpdateNewMessage, types.UpdateNewChannelMessage)):
-                        return pyrogram.Message.parse(
+                        return pyrogram.Message._parse(
                             self, i.message,
                             {i.id: i for i in r.users},
                             {i.id: i for i in r.chats}

--- a/pyrogram/client/methods/messages/send_document.py
+++ b/pyrogram/client/methods/messages/send_document.py
@@ -42,7 +42,7 @@ class SendDocument(BaseClient):
                                           "pyrogram.ReplyKeyboardRemove",
                                           "pyrogram.ForceReply"] = None,
                       progress: callable = None,
-                      progress_args: tuple = ()):
+                      progress_args: tuple = ()) -> "pyrogram.Message":
         """Use this method to send general files.
 
         Args:

--- a/pyrogram/client/methods/messages/send_location.py
+++ b/pyrogram/client/methods/messages/send_location.py
@@ -33,7 +33,7 @@ class SendLocation(BaseClient):
                       reply_markup: Union["pyrogram.InlineKeyboardMarkup",
                                           "pyrogram.ReplyKeyboardMarkup",
                                           "pyrogram.ReplyKeyboardRemove",
-                                          "pyrogram.ForceReply"] = None):
+                                          "pyrogram.ForceReply"] = None) -> "pyrogram.Message":
         """Use this method to send points on the map.
 
         Args:

--- a/pyrogram/client/methods/messages/send_location.py
+++ b/pyrogram/client/methods/messages/send_location.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import Union
+
 import pyrogram
 from pyrogram.api import functions, types
 from pyrogram.client.ext import BaseClient
@@ -23,12 +25,15 @@ from pyrogram.client.ext import BaseClient
 
 class SendLocation(BaseClient):
     def send_location(self,
-                      chat_id: int or str,
+                      chat_id: Union[int, str],
                       latitude: float,
                       longitude: float,
                       disable_notification: bool = None,
                       reply_to_message_id: int = None,
-                      reply_markup=None):
+                      reply_markup: Union["pyrogram.InlineKeyboardMarkup",
+                                          "pyrogram.ReplyKeyboardMarkup",
+                                          "pyrogram.ReplyKeyboardRemove",
+                                          "pyrogram.ForceReply"] = None):
         """Use this method to send points on the map.
 
         Args:
@@ -79,7 +84,7 @@ class SendLocation(BaseClient):
 
         for i in r.updates:
             if isinstance(i, (types.UpdateNewMessage, types.UpdateNewChannelMessage)):
-                return pyrogram.Message.parse(
+                return pyrogram.Message._parse(
                     self, i.message,
                     {i.id: i for i in r.users},
                     {i.id: i for i in r.chats}

--- a/pyrogram/client/methods/messages/send_media_group.py
+++ b/pyrogram/client/methods/messages/send_media_group.py
@@ -20,10 +20,11 @@ import binascii
 import mimetypes
 import os
 import struct
+from typing import Union, List
 
+import pyrogram
 from pyrogram.api import functions, types
 from pyrogram.api.errors import FileIdInvalid
-from pyrogram.client import types as pyrogram_types
 from pyrogram.client.ext import BaseClient, utils
 
 
@@ -32,8 +33,8 @@ class SendMediaGroup(BaseClient):
     # TODO: Return new Message object
     # TODO: Figure out how to send albums using URLs
     def send_media_group(self,
-                         chat_id: int or str,
-                         media: list,
+                         chat_id: Union[int, str],
+                         media: List[Union["pyrogram.InputMediaPhoto", "pyrogram.InputMediaVideo"]],
                          disable_notification: bool = None,
                          reply_to_message_id: int = None):
         """Use this method to send a group of photos or videos as an album.
@@ -62,7 +63,7 @@ class SendMediaGroup(BaseClient):
         for i in media:
             style = self.html if i.parse_mode.lower() == "html" else self.markdown
 
-            if isinstance(i, pyrogram_types.InputMediaPhoto):
+            if isinstance(i, pyrogram.InputMediaPhoto):
                 if os.path.exists(i.media):
                     media = self.send(
                         functions.messages.UploadMedia(
@@ -101,7 +102,7 @@ class SendMediaGroup(BaseClient):
                                 access_hash=unpacked[3]
                             )
                         )
-            elif isinstance(i, pyrogram_types.InputMediaVideo):
+            elif isinstance(i, pyrogram.InputMediaVideo):
                 if os.path.exists(i.media):
                     media = self.send(
                         functions.messages.UploadMedia(

--- a/pyrogram/client/methods/messages/send_message.py
+++ b/pyrogram/client/methods/messages/send_message.py
@@ -34,7 +34,7 @@ class SendMessage(BaseClient):
                      reply_markup: Union["pyrogram.InlineKeyboardMarkup",
                                          "pyrogram.ReplyKeyboardMarkup",
                                          "pyrogram.ReplyKeyboardRemove",
-                                         "pyrogram.ForceReply"] = None):
+                                         "pyrogram.ForceReply"] = None) -> "pyrogram.Message":
         """Use this method to send text messages.
 
         Args:

--- a/pyrogram/client/methods/messages/send_message.py
+++ b/pyrogram/client/methods/messages/send_message.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import Union
+
 import pyrogram
 from pyrogram.api import functions, types
 from ...ext import BaseClient
@@ -23,13 +25,16 @@ from ...ext import BaseClient
 
 class SendMessage(BaseClient):
     def send_message(self,
-                     chat_id: int or str,
+                     chat_id: Union[int, str],
                      text: str,
                      parse_mode: str = "",
                      disable_web_page_preview: bool = None,
                      disable_notification: bool = None,
                      reply_to_message_id: int = None,
-                     reply_markup=None):
+                     reply_markup: Union["pyrogram.InlineKeyboardMarkup",
+                                         "pyrogram.ReplyKeyboardMarkup",
+                                         "pyrogram.ReplyKeyboardRemove",
+                                         "pyrogram.ForceReply"] = None):
         """Use this method to send text messages.
 
         Args:
@@ -99,7 +104,7 @@ class SendMessage(BaseClient):
 
         for i in r.updates:
             if isinstance(i, (types.UpdateNewMessage, types.UpdateNewChannelMessage)):
-                return pyrogram.Message.parse(
+                return pyrogram.Message._parse(
                     self, i.message,
                     {i.id: i for i in r.users},
                     {i.id: i for i in r.chats}

--- a/pyrogram/client/methods/messages/send_photo.py
+++ b/pyrogram/client/methods/messages/send_photo.py
@@ -41,7 +41,7 @@ class SendPhoto(BaseClient):
                                        "pyrogram.ReplyKeyboardRemove",
                                        "pyrogram.ForceReply"] = None,
                    progress: callable = None,
-                   progress_args: tuple = ()):
+                   progress_args: tuple = ()) -> "pyrogram.Message":
         """Use this method to send photos.
 
         Args:

--- a/pyrogram/client/methods/messages/send_photo.py
+++ b/pyrogram/client/methods/messages/send_photo.py
@@ -19,6 +19,7 @@
 import binascii
 import os
 import struct
+from typing import Union
 
 import pyrogram
 from pyrogram.api import functions, types
@@ -28,14 +29,17 @@ from pyrogram.client.ext import BaseClient, utils
 
 class SendPhoto(BaseClient):
     def send_photo(self,
-                   chat_id: int or str,
+                   chat_id: Union[int, str],
                    photo: str,
                    caption: str = "",
                    parse_mode: str = "",
                    ttl_seconds: int = None,
                    disable_notification: bool = None,
                    reply_to_message_id: int = None,
-                   reply_markup=None,
+                   reply_markup: Union["pyrogram.InlineKeyboardMarkup",
+                                       "pyrogram.ReplyKeyboardMarkup",
+                                       "pyrogram.ReplyKeyboardRemove",
+                                       "pyrogram.ForceReply"] = None,
                    progress: callable = None,
                    progress_args: tuple = ()):
         """Use this method to send photos.
@@ -161,7 +165,7 @@ class SendPhoto(BaseClient):
             else:
                 for i in r.updates:
                     if isinstance(i, (types.UpdateNewMessage, types.UpdateNewChannelMessage)):
-                        return pyrogram.Message.parse(
+                        return pyrogram.Message._parse(
                             self, i.message,
                             {i.id: i for i in r.users},
                             {i.id: i for i in r.chats}

--- a/pyrogram/client/methods/messages/send_sticker.py
+++ b/pyrogram/client/methods/messages/send_sticker.py
@@ -19,6 +19,7 @@
 import binascii
 import os
 import struct
+from typing import Union
 
 import pyrogram
 from pyrogram.api import functions, types
@@ -28,11 +29,14 @@ from pyrogram.client.ext import BaseClient, utils
 
 class SendSticker(BaseClient):
     def send_sticker(self,
-                     chat_id: int or str,
+                     chat_id: Union[int, str],
                      sticker: str,
                      disable_notification: bool = None,
                      reply_to_message_id: int = None,
-                     reply_markup=None,
+                     reply_markup: Union["pyrogram.InlineKeyboardMarkup",
+                                         "pyrogram.ReplyKeyboardMarkup",
+                                         "pyrogram.ReplyKeyboardRemove",
+                                         "pyrogram.ForceReply"] = None,
                      progress: callable = None,
                      progress_args: tuple = ()):
         """Use this method to send .webp stickers.
@@ -145,7 +149,7 @@ class SendSticker(BaseClient):
             else:
                 for i in r.updates:
                     if isinstance(i, (types.UpdateNewMessage, types.UpdateNewChannelMessage)):
-                        return pyrogram.Message.parse(
+                        return pyrogram.Message._parse(
                             self, i.message,
                             {i.id: i for i in r.users},
                             {i.id: i for i in r.chats}

--- a/pyrogram/client/methods/messages/send_sticker.py
+++ b/pyrogram/client/methods/messages/send_sticker.py
@@ -38,7 +38,7 @@ class SendSticker(BaseClient):
                                          "pyrogram.ReplyKeyboardRemove",
                                          "pyrogram.ForceReply"] = None,
                      progress: callable = None,
-                     progress_args: tuple = ()):
+                     progress_args: tuple = ()) -> "pyrogram.Message":
         """Use this method to send .webp stickers.
 
         Args:

--- a/pyrogram/client/methods/messages/send_venue.py
+++ b/pyrogram/client/methods/messages/send_venue.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import Union
+
 import pyrogram
 from pyrogram.api import functions, types
 from pyrogram.client.ext import BaseClient
@@ -23,7 +25,7 @@ from pyrogram.client.ext import BaseClient
 
 class SendVenue(BaseClient):
     def send_venue(self,
-                   chat_id: int or str,
+                   chat_id: Union[int, str],
                    latitude: float,
                    longitude: float,
                    title: str,
@@ -32,7 +34,10 @@ class SendVenue(BaseClient):
                    foursquare_type: str = "",
                    disable_notification: bool = None,
                    reply_to_message_id: int = None,
-                   reply_markup=None):
+                   reply_markup: Union["pyrogram.InlineKeyboardMarkup",
+                                       "pyrogram.ReplyKeyboardMarkup",
+                                       "pyrogram.ReplyKeyboardRemove",
+                                       "pyrogram.ForceReply"] = None):
         """Use this method to send information about a venue.
 
         Args:
@@ -101,7 +106,7 @@ class SendVenue(BaseClient):
 
         for i in r.updates:
             if isinstance(i, (types.UpdateNewMessage, types.UpdateNewChannelMessage)):
-                return pyrogram.Message.parse(
+                return pyrogram.Message._parse(
                     self, i.message,
                     {i.id: i for i in r.users},
                     {i.id: i for i in r.chats}

--- a/pyrogram/client/methods/messages/send_venue.py
+++ b/pyrogram/client/methods/messages/send_venue.py
@@ -37,7 +37,7 @@ class SendVenue(BaseClient):
                    reply_markup: Union["pyrogram.InlineKeyboardMarkup",
                                        "pyrogram.ReplyKeyboardMarkup",
                                        "pyrogram.ReplyKeyboardRemove",
-                                       "pyrogram.ForceReply"] = None):
+                                       "pyrogram.ForceReply"] = None) -> "pyrogram.Message":
         """Use this method to send information about a venue.
 
         Args:

--- a/pyrogram/client/methods/messages/send_video.py
+++ b/pyrogram/client/methods/messages/send_video.py
@@ -20,6 +20,7 @@ import binascii
 import mimetypes
 import os
 import struct
+from typing import Union
 
 import pyrogram
 from pyrogram.api import functions, types
@@ -29,7 +30,7 @@ from pyrogram.client.ext import BaseClient, utils
 
 class SendVideo(BaseClient):
     def send_video(self,
-                   chat_id: int or str,
+                   chat_id: Union[int, str],
                    video: str,
                    caption: str = "",
                    parse_mode: str = "",
@@ -40,7 +41,10 @@ class SendVideo(BaseClient):
                    supports_streaming: bool = True,
                    disable_notification: bool = None,
                    reply_to_message_id: int = None,
-                   reply_markup=None,
+                   reply_markup: Union["pyrogram.InlineKeyboardMarkup",
+                                       "pyrogram.ReplyKeyboardMarkup",
+                                       "pyrogram.ReplyKeyboardRemove",
+                                       "pyrogram.ForceReply"] = None,
                    progress: callable = None,
                    progress_args: tuple = ()):
         """Use this method to send video files.
@@ -188,7 +192,7 @@ class SendVideo(BaseClient):
             else:
                 for i in r.updates:
                     if isinstance(i, (types.UpdateNewMessage, types.UpdateNewChannelMessage)):
-                        return pyrogram.Message.parse(
+                        return pyrogram.Message._parse(
                             self, i.message,
                             {i.id: i for i in r.users},
                             {i.id: i for i in r.chats}

--- a/pyrogram/client/methods/messages/send_video.py
+++ b/pyrogram/client/methods/messages/send_video.py
@@ -46,7 +46,7 @@ class SendVideo(BaseClient):
                                        "pyrogram.ReplyKeyboardRemove",
                                        "pyrogram.ForceReply"] = None,
                    progress: callable = None,
-                   progress_args: tuple = ()):
+                   progress_args: tuple = ()) -> "pyrogram.Message":
         """Use this method to send video files.
 
         Args:

--- a/pyrogram/client/methods/messages/send_video_note.py
+++ b/pyrogram/client/methods/messages/send_video_note.py
@@ -42,7 +42,7 @@ class SendVideoNote(BaseClient):
                                             "pyrogram.ReplyKeyboardRemove",
                                             "pyrogram.ForceReply"] = None,
                         progress: callable = None,
-                        progress_args: tuple = ()):
+                        progress_args: tuple = ()) -> "pyrogram.Message":
         """Use this method to send video messages.
 
         Args:

--- a/pyrogram/client/methods/messages/send_video_note.py
+++ b/pyrogram/client/methods/messages/send_video_note.py
@@ -20,6 +20,7 @@ import binascii
 import mimetypes
 import os
 import struct
+from typing import Union
 
 import pyrogram
 from pyrogram.api import functions, types
@@ -29,14 +30,17 @@ from pyrogram.client.ext import BaseClient, utils
 
 class SendVideoNote(BaseClient):
     def send_video_note(self,
-                        chat_id: int or str,
+                        chat_id: Union[int, str],
                         video_note: str,
                         duration: int = 0,
                         length: int = 1,
                         thumb: str = None,
                         disable_notification: bool = None,
                         reply_to_message_id: int = None,
-                        reply_markup=None,
+                        reply_markup: Union["pyrogram.InlineKeyboardMarkup",
+                                            "pyrogram.ReplyKeyboardMarkup",
+                                            "pyrogram.ReplyKeyboardRemove",
+                                            "pyrogram.ForceReply"] = None,
                         progress: callable = None,
                         progress_args: tuple = ()):
         """Use this method to send video messages.
@@ -164,7 +168,7 @@ class SendVideoNote(BaseClient):
             else:
                 for i in r.updates:
                     if isinstance(i, (types.UpdateNewMessage, types.UpdateNewChannelMessage)):
-                        return pyrogram.Message.parse(
+                        return pyrogram.Message._parse(
                             self, i.message,
                             {i.id: i for i in r.users},
                             {i.id: i for i in r.chats}

--- a/pyrogram/client/methods/messages/send_voice.py
+++ b/pyrogram/client/methods/messages/send_voice.py
@@ -42,7 +42,7 @@ class SendVoice(BaseClient):
                                        "pyrogram.ReplyKeyboardRemove",
                                        "pyrogram.ForceReply"] = None,
                    progress: callable = None,
-                   progress_args: tuple = ()):
+                   progress_args: tuple = ()) -> "pyrogram.Message":
         """Use this method to send audio files.
 
         Args:

--- a/pyrogram/client/methods/messages/send_voice.py
+++ b/pyrogram/client/methods/messages/send_voice.py
@@ -20,6 +20,7 @@ import binascii
 import mimetypes
 import os
 import struct
+from typing import Union
 
 import pyrogram
 from pyrogram.api import functions, types
@@ -29,14 +30,17 @@ from pyrogram.client.ext import BaseClient, utils
 
 class SendVoice(BaseClient):
     def send_voice(self,
-                   chat_id: int or str,
+                   chat_id: Union[int, str],
                    voice: str,
                    caption: str = "",
                    parse_mode: str = "",
                    duration: int = 0,
                    disable_notification: bool = None,
                    reply_to_message_id: int = None,
-                   reply_markup=None,
+                   reply_markup: Union["pyrogram.InlineKeyboardMarkup",
+                                       "pyrogram.ReplyKeyboardMarkup",
+                                       "pyrogram.ReplyKeyboardRemove",
+                                       "pyrogram.ForceReply"] = None,
                    progress: callable = None,
                    progress_args: tuple = ()):
         """Use this method to send audio files.
@@ -164,7 +168,7 @@ class SendVoice(BaseClient):
             else:
                 for i in r.updates:
                     if isinstance(i, (types.UpdateNewMessage, types.UpdateNewChannelMessage)):
-                        return pyrogram.Message.parse(
+                        return pyrogram.Message._parse(
                             self, i.message,
                             {i.id: i for i in r.users},
                             {i.id: i for i in r.chats}

--- a/pyrogram/client/methods/password/change_cloud_password.py
+++ b/pyrogram/client/methods/password/change_cloud_password.py
@@ -24,7 +24,10 @@ from ...ext import BaseClient
 
 
 class ChangeCloudPassword(BaseClient):
-    def change_cloud_password(self, current_password: str, new_password: str, new_hint: str = ""):
+    def change_cloud_password(self,
+                              current_password: str,
+                              new_password: str,
+                              new_hint: str = ""):
         """Use this method to change your Two-Step Verification password (Cloud Password) with a new one.
 
         Args:

--- a/pyrogram/client/methods/password/change_cloud_password.py
+++ b/pyrogram/client/methods/password/change_cloud_password.py
@@ -27,7 +27,7 @@ class ChangeCloudPassword(BaseClient):
     def change_cloud_password(self,
                               current_password: str,
                               new_password: str,
-                              new_hint: str = ""):
+                              new_hint: str = "") -> bool:
         """Use this method to change your Two-Step Verification password (Cloud Password) with a new one.
 
         Args:

--- a/pyrogram/client/methods/password/enable_cloud_password.py
+++ b/pyrogram/client/methods/password/enable_cloud_password.py
@@ -24,7 +24,10 @@ from ...ext import BaseClient
 
 
 class EnableCloudPassword(BaseClient):
-    def enable_cloud_password(self, password: str, hint: str = "", email: str = ""):
+    def enable_cloud_password(self,
+                              password: str,
+                              hint: str = "",
+                              email: str = ""):
         """Use this method to enable the Two-Step Verification security feature (Cloud Password) on your account.
 
         This password will be asked when you log in on a new device in addition to the SMS code.

--- a/pyrogram/client/methods/password/enable_cloud_password.py
+++ b/pyrogram/client/methods/password/enable_cloud_password.py
@@ -27,7 +27,7 @@ class EnableCloudPassword(BaseClient):
     def enable_cloud_password(self,
                               password: str,
                               hint: str = "",
-                              email: str = ""):
+                              email: str = "") -> bool:
         """Use this method to enable the Two-Step Verification security feature (Cloud Password) on your account.
 
         This password will be asked when you log in on a new device in addition to the SMS code.

--- a/pyrogram/client/methods/password/remove_cloud_password.py
+++ b/pyrogram/client/methods/password/remove_cloud_password.py
@@ -23,7 +23,8 @@ from ...ext import BaseClient
 
 
 class RemoveCloudPassword(BaseClient):
-    def remove_cloud_password(self, password: str):
+    def remove_cloud_password(self,
+                              password: str):
         """Use this method to turn off the Two-Step Verification security feature (Cloud Password) on your account.
 
         Args:

--- a/pyrogram/client/methods/password/remove_cloud_password.py
+++ b/pyrogram/client/methods/password/remove_cloud_password.py
@@ -24,7 +24,7 @@ from ...ext import BaseClient
 
 class RemoveCloudPassword(BaseClient):
     def remove_cloud_password(self,
-                              password: str):
+                              password: str) -> bool:
         """Use this method to turn off the Two-Step Verification security feature (Cloud Password) on your account.
 
         Args:

--- a/pyrogram/client/methods/users/delete_user_profile_photos.py
+++ b/pyrogram/client/methods/users/delete_user_profile_photos.py
@@ -18,13 +18,15 @@
 
 from base64 import b64decode
 from struct import unpack
+from typing import List, Union
 
 from pyrogram.api import functions, types
 from ...ext import BaseClient
 
 
 class DeleteUserProfilePhotos(BaseClient):
-    def delete_user_profile_photos(self, id: str or list):
+    def delete_user_profile_photos(self,
+                                   id: Union[str, List[str]]):
         """Use this method to delete your own profile photos
 
         Args:

--- a/pyrogram/client/methods/users/delete_user_profile_photos.py
+++ b/pyrogram/client/methods/users/delete_user_profile_photos.py
@@ -26,7 +26,7 @@ from ...ext import BaseClient
 
 class DeleteUserProfilePhotos(BaseClient):
     def delete_user_profile_photos(self,
-                                   id: Union[str, List[str]]):
+                                   id: Union[str, List[str]]) -> bool:
         """Use this method to delete your own profile photos
 
         Args:

--- a/pyrogram/client/methods/users/get_me.py
+++ b/pyrogram/client/methods/users/get_me.py
@@ -22,7 +22,7 @@ from ...ext import BaseClient
 
 
 class GetMe(BaseClient):
-    def get_me(self):
+    def get_me(self) -> pyrogram.User:
         """A simple method for testing your authorization. Requires no parameters.
 
         Returns:

--- a/pyrogram/client/methods/users/get_me.py
+++ b/pyrogram/client/methods/users/get_me.py
@@ -31,7 +31,7 @@ class GetMe(BaseClient):
         Raises:
             :class:`Error <pyrogram.Error>` in case of a Telegram RPC error.
         """
-        return pyrogram.User.parse(
+        return pyrogram.User._parse(
             self,
             self.send(
                 functions.users.GetFullUser(

--- a/pyrogram/client/methods/users/get_user_profile_photos.py
+++ b/pyrogram/client/methods/users/get_user_profile_photos.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import Union
+
 import pyrogram
 from pyrogram.api import functions
 from ...ext import BaseClient
@@ -23,7 +25,7 @@ from ...ext import BaseClient
 
 class GetUserProfilePhotos(BaseClient):
     def get_user_profile_photos(self,
-                                user_id: int or str,
+                                user_id: Union[int, str],
                                 offset: int = 0,
                                 limit: int = 100):
         """Use this method to get a list of profile pictures for a user.
@@ -48,7 +50,7 @@ class GetUserProfilePhotos(BaseClient):
         Raises:
             :class:`Error <pyrogram.Error>` in case of a Telegram RPC error.
         """
-        return pyrogram.UserProfilePhotos.parse(
+        return pyrogram.UserProfilePhotos._parse(
             self,
             self.send(
                 functions.photos.GetUserPhotos(

--- a/pyrogram/client/methods/users/get_user_profile_photos.py
+++ b/pyrogram/client/methods/users/get_user_profile_photos.py
@@ -27,7 +27,7 @@ class GetUserProfilePhotos(BaseClient):
     def get_user_profile_photos(self,
                                 user_id: Union[int, str],
                                 offset: int = 0,
-                                limit: int = 100):
+                                limit: int = 100) -> pyrogram.UserProfilePhotos:
         """Use this method to get a list of profile pictures for a user.
 
         Args:

--- a/pyrogram/client/methods/users/get_users.py
+++ b/pyrogram/client/methods/users/get_users.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Iterable, Union
+from typing import Iterable, Union, List
 
 import pyrogram
 from pyrogram.api import functions
@@ -25,7 +25,7 @@ from ...ext import BaseClient
 
 class GetUsers(BaseClient):
     def get_users(self,
-                  user_ids: Iterable[Union[int, str]]):
+                  user_ids: Iterable[Union[int, str]]) -> Union[pyrogram.User or List[pyrogram.User]]:
         """Use this method to get information about a user.
         You can retrieve up to 200 users at once.
 
@@ -36,9 +36,9 @@ class GetUsers(BaseClient):
                 Iterators and Generators are also accepted.
 
         Returns:
-            On success and in case *user_ids* was a list, the returned value will be a list of the requested
+            On success and in case *user_ids* was an iterable, the returned value will be a list of the requested
             :obj:`Users <User>` even if a list contains just one element, otherwise if
-            *user_ids* was an integer, the single requested :obj:`User` is returned.
+            *user_ids* was an integer or string, the single requested :obj:`User` is returned.
 
         Raises:
             :class:`Error <pyrogram.Error>` in case of a Telegram RPC error.

--- a/pyrogram/client/methods/users/get_users.py
+++ b/pyrogram/client/methods/users/get_users.py
@@ -16,13 +16,16 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import Iterable, Union
+
 import pyrogram
 from pyrogram.api import functions
 from ...ext import BaseClient
 
 
 class GetUsers(BaseClient):
-    def get_users(self, user_ids):
+    def get_users(self,
+                  user_ids: Iterable[Union[int, str]]):
         """Use this method to get information about a user.
         You can retrieve up to 200 users at once.
 
@@ -53,6 +56,6 @@ class GetUsers(BaseClient):
         users = []
 
         for i in r:
-            users.append(pyrogram.User.parse(self, i))
+            users.append(pyrogram.User._parse(self, i))
 
         return users if is_iterable else users[0]

--- a/pyrogram/client/methods/users/set_user_profile_photo.py
+++ b/pyrogram/client/methods/users/set_user_profile_photo.py
@@ -21,7 +21,8 @@ from ...ext import BaseClient
 
 
 class SetUserProfilePhoto(BaseClient):
-    def set_user_profile_photo(self, photo: str):
+    def set_user_profile_photo(self,
+                               photo: str):
         """Use this method to set a new profile photo.
 
         This method only works for Users.

--- a/pyrogram/client/methods/users/set_user_profile_photo.py
+++ b/pyrogram/client/methods/users/set_user_profile_photo.py
@@ -22,7 +22,7 @@ from ...ext import BaseClient
 
 class SetUserProfilePhoto(BaseClient):
     def set_user_profile_photo(self,
-                               photo: str):
+                               photo: str) -> bool:
         """Use this method to set a new profile photo.
 
         This method only works for Users.

--- a/pyrogram/client/methods/utilities/download_media.py
+++ b/pyrogram/client/methods/utilities/download_media.py
@@ -29,7 +29,7 @@ class DownloadMedia(BaseClient):
                        file_name: str = "",
                        block: bool = True,
                        progress: callable = None,
-                       progress_args: tuple = ()):
+                       progress_args: tuple = ()) -> Union[str, None]:
         """Use this method to download the media from a Message.
 
         Args:

--- a/pyrogram/client/methods/utilities/download_media.py
+++ b/pyrogram/client/methods/utilities/download_media.py
@@ -17,14 +17,15 @@
 # along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 from threading import Event
+from typing import Union
 
-from pyrogram.client import types as pyrogram_types
+import pyrogram
 from ...ext import BaseClient
 
 
 class DownloadMedia(BaseClient):
     def download_media(self,
-                       message: pyrogram_types.Message or str,
+                       message: Union["pyrogram.Message", str],
                        file_name: str = "",
                        block: bool = True,
                        progress: callable = None,
@@ -78,9 +79,9 @@ class DownloadMedia(BaseClient):
         """
         error_message = "This message doesn't contain any downloadable media"
 
-        if isinstance(message, pyrogram_types.Message):
+        if isinstance(message, pyrogram.Message):
             if message.photo:
-                media = pyrogram_types.Document(
+                media = pyrogram.Document(
                     file_id=message.photo.sizes[-1].file_id,
                     file_size=message.photo.sizes[-1].file_size,
                     mime_type="",
@@ -104,18 +105,18 @@ class DownloadMedia(BaseClient):
             else:
                 raise ValueError(error_message)
         elif isinstance(message, (
-                pyrogram_types.Photo,
-                pyrogram_types.PhotoSize,
-                pyrogram_types.Audio,
-                pyrogram_types.Document,
-                pyrogram_types.Video,
-                pyrogram_types.Voice,
-                pyrogram_types.VideoNote,
-                pyrogram_types.Sticker,
-                pyrogram_types.Animation
+                pyrogram.Photo,
+                pyrogram.PhotoSize,
+                pyrogram.Audio,
+                pyrogram.Document,
+                pyrogram.Video,
+                pyrogram.Voice,
+                pyrogram.VideoNote,
+                pyrogram.Sticker,
+                pyrogram.Animation
         )):
-            if isinstance(message, pyrogram_types.Photo):
-                media = pyrogram_types.Document(
+            if isinstance(message, pyrogram.Photo):
+                media = pyrogram.Document(
                     file_id=message.sizes[-1].file_id,
                     file_size=message.sizes[-1].file_size,
                     mime_type="",
@@ -125,7 +126,7 @@ class DownloadMedia(BaseClient):
             else:
                 media = message
         elif isinstance(message, str):
-            media = pyrogram_types.Document(
+            media = pyrogram.Document(
                 file_id=message,
                 file_size=0,
                 mime_type="",

--- a/pyrogram/client/types/bots/callback_query.py
+++ b/pyrogram/client/types/bots/callback_query.py
@@ -19,6 +19,7 @@
 from base64 import b64encode
 from struct import pack
 
+import pyrogram
 from pyrogram.api import types
 from ..pyrogram_type import PyrogramType
 from ..user_and_chats import User
@@ -58,11 +59,11 @@ class CallbackQuery(PyrogramType):
 
     def __init__(self,
                  *,
-                 client,
+                 client: "pyrogram.Client",
                  id: str,
-                 from_user,
+                 from_user: User,
                  chat_instance: str,
-                 message=None,
+                 message: "pyrogram.Message" = None,
                  inline_message_id: str = None,
                  data: bytes = None,
                  game_short_name: str = None):

--- a/pyrogram/client/types/bots/callback_query.py
+++ b/pyrogram/client/types/bots/callback_query.py
@@ -77,7 +77,7 @@ class CallbackQuery(PyrogramType):
         self.game_short_name = game_short_name
 
     @staticmethod
-    def parse(client, callback_query, users) -> "CallbackQuery":
+    def _parse(client, callback_query, users) -> "CallbackQuery":
         message = None
         inline_message_id = None
 
@@ -105,7 +105,7 @@ class CallbackQuery(PyrogramType):
 
         return CallbackQuery(
             id=str(callback_query.query_id),
-            from_user=User.parse(client, users[callback_query.user_id]),
+            from_user=User._parse(client, users[callback_query.user_id]),
             message=message,
             inline_message_id=inline_message_id,
             chat_instance=str(callback_query.chat_instance),

--- a/pyrogram/client/types/bots/callback_query.py
+++ b/pyrogram/client/types/bots/callback_query.py
@@ -59,7 +59,7 @@ class CallbackQuery(PyrogramType):
 
     def __init__(self,
                  *,
-                 client: "pyrogram.Client",
+                 client: "pyrogram.client.ext.BaseClient",
                  id: str,
                  from_user: User,
                  chat_instance: str,

--- a/pyrogram/client/types/bots/inline_keyboard_markup.py
+++ b/pyrogram/client/types/bots/inline_keyboard_markup.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import List
+
 from pyrogram.api.types import ReplyInlineMarkup, KeyboardButtonRow
 from . import InlineKeyboardButton
 from ..pyrogram_type import PyrogramType
@@ -30,7 +32,7 @@ class InlineKeyboardMarkup(PyrogramType):
     """
 
     def __init__(self,
-                 inline_keyboard: list):
+                 inline_keyboard: List[List[InlineKeyboardButton]]):
         super().__init__(None)
 
         self.inline_keyboard = inline_keyboard

--- a/pyrogram/client/types/bots/reply_keyboard_markup.py
+++ b/pyrogram/client/types/bots/reply_keyboard_markup.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import List
+
 from pyrogram.api.types import KeyboardButtonRow
 from pyrogram.api.types import ReplyKeyboardMarkup as RawReplyKeyboardMarkup
 from . import KeyboardButton
@@ -48,7 +50,7 @@ class ReplyKeyboardMarkup(PyrogramType):
     """
 
     def __init__(self,
-                 keyboard: list,
+                 keyboard: List[List[KeyboardButton]],
                  resize_keyboard: bool = None,
                  one_time_keyboard: bool = None,
                  selective: bool = None):

--- a/pyrogram/client/types/messages_and_media/animation.py
+++ b/pyrogram/client/types/messages_and_media/animation.py
@@ -59,7 +59,7 @@ class Animation(PyrogramType):
 
     def __init__(self,
                  *,
-                 client: "pyrogram.Client",
+                 client: "pyrogram.client.ext.BaseClient",
                  file_id: str,
                  width: int,
                  height: int,

--- a/pyrogram/client/types/messages_and_media/animation.py
+++ b/pyrogram/client/types/messages_and_media/animation.py
@@ -18,6 +18,7 @@
 
 from struct import pack
 
+import pyrogram
 from pyrogram.api import types
 from .photo_size import PhotoSize
 from ..pyrogram_type import PyrogramType
@@ -58,12 +59,12 @@ class Animation(PyrogramType):
 
     def __init__(self,
                  *,
-                 client,
+                 client: "pyrogram.Client",
                  file_id: str,
                  width: int,
                  height: int,
                  duration: int,
-                 thumb=None,
+                 thumb: PhotoSize = None,
                  file_name: str = None,
                  mime_type: str = None,
                  file_size: int = None,
@@ -82,7 +83,7 @@ class Animation(PyrogramType):
 
     @staticmethod
     def _parse(client, animation: types.Document, video_attributes: types.DocumentAttributeVideo,
-              file_name: str) -> "Animation":
+               file_name: str) -> "Animation":
         return Animation(
             file_id=encode(
                 pack(

--- a/pyrogram/client/types/messages_and_media/animation.py
+++ b/pyrogram/client/types/messages_and_media/animation.py
@@ -81,7 +81,7 @@ class Animation(PyrogramType):
         self.duration = duration
 
     @staticmethod
-    def parse(client, animation: types.Document, video_attributes: types.DocumentAttributeVideo,
+    def _parse(client, animation: types.Document, video_attributes: types.DocumentAttributeVideo,
               file_name: str) -> "Animation":
         return Animation(
             file_id=encode(
@@ -96,7 +96,7 @@ class Animation(PyrogramType):
             width=getattr(video_attributes, "w", 0),
             height=getattr(video_attributes, "h", 0),
             duration=getattr(video_attributes, "duration", 0),
-            thumb=PhotoSize.parse(client, animation.thumb),
+            thumb=PhotoSize._parse(client, animation.thumb),
             mime_type=animation.mime_type,
             file_size=animation.size,
             file_name=file_name,

--- a/pyrogram/client/types/messages_and_media/audio.py
+++ b/pyrogram/client/types/messages_and_media/audio.py
@@ -18,6 +18,7 @@
 
 from struct import pack
 
+import pyrogram
 from pyrogram.api import types
 from .photo_size import PhotoSize
 from ..pyrogram_type import PyrogramType
@@ -58,10 +59,10 @@ class Audio(PyrogramType):
 
     def __init__(self,
                  *,
-                 client,
+                 client: "pyrogram.Client",
                  file_id: str,
                  duration: int,
-                 thumb=None,
+                 thumb: PhotoSize = None,
                  file_name: str = None,
                  mime_type: str = None,
                  file_size: int = None,
@@ -81,7 +82,8 @@ class Audio(PyrogramType):
         self.title = title
 
     @staticmethod
-    def _parse(client, audio: types.Document, audio_attributes: types.DocumentAttributeAudio, file_name: str) -> "Audio":
+    def _parse(client, audio: types.Document, audio_attributes: types.DocumentAttributeAudio,
+               file_name: str) -> "Audio":
         return Audio(
             file_id=encode(
                 pack(

--- a/pyrogram/client/types/messages_and_media/audio.py
+++ b/pyrogram/client/types/messages_and_media/audio.py
@@ -59,7 +59,7 @@ class Audio(PyrogramType):
 
     def __init__(self,
                  *,
-                 client: "pyrogram.Client",
+                 client: "pyrogram.client.ext.BaseClient",
                  file_id: str,
                  duration: int,
                  thumb: PhotoSize = None,

--- a/pyrogram/client/types/messages_and_media/audio.py
+++ b/pyrogram/client/types/messages_and_media/audio.py
@@ -81,7 +81,7 @@ class Audio(PyrogramType):
         self.title = title
 
     @staticmethod
-    def parse(client, audio: types.Document, audio_attributes: types.DocumentAttributeAudio, file_name: str) -> "Audio":
+    def _parse(client, audio: types.Document, audio_attributes: types.DocumentAttributeAudio, file_name: str) -> "Audio":
         return Audio(
             file_id=encode(
                 pack(
@@ -97,7 +97,7 @@ class Audio(PyrogramType):
             title=audio_attributes.title,
             mime_type=audio.mime_type,
             file_size=audio.size,
-            thumb=PhotoSize.parse(client, audio.thumb),
+            thumb=PhotoSize._parse(client, audio.thumb),
             file_name=file_name,
             date=audio.date,
             client=client

--- a/pyrogram/client/types/messages_and_media/contact.py
+++ b/pyrogram/client/types/messages_and_media/contact.py
@@ -44,7 +44,7 @@ class Contact(PyrogramType):
 
     def __init__(self,
                  *,
-                 client: "pyrogram.Client",
+                 client: "pyrogram.client.ext.BaseClient",
                  phone_number: str,
                  first_name: str,
                  last_name: str = None,

--- a/pyrogram/client/types/messages_and_media/contact.py
+++ b/pyrogram/client/types/messages_and_media/contact.py
@@ -57,7 +57,7 @@ class Contact(PyrogramType):
         self.vcard = vcard
 
     @staticmethod
-    def parse(client, contact: types.MessageMediaContact) -> "Contact":
+    def _parse(client, contact: types.MessageMediaContact) -> "Contact":
         return Contact(
             phone_number=contact.phone_number,
             first_name=contact.first_name,

--- a/pyrogram/client/types/messages_and_media/contact.py
+++ b/pyrogram/client/types/messages_and_media/contact.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+import pyrogram
+
 from pyrogram.api import types
 from ..pyrogram_type import PyrogramType
 
@@ -42,7 +44,7 @@ class Contact(PyrogramType):
 
     def __init__(self,
                  *,
-                 client,
+                 client: "pyrogram.Client",
                  phone_number: str,
                  first_name: str,
                  last_name: str = None,

--- a/pyrogram/client/types/messages_and_media/document.py
+++ b/pyrogram/client/types/messages_and_media/document.py
@@ -50,7 +50,7 @@ class Document(PyrogramType):
 
     def __init__(self,
                  *,
-                 client: "pyrogram.Client",
+                 client: "pyrogram.client.ext.BaseClient",
                  file_id: str,
                  thumb: PhotoSize = None,
                  file_name: str = None,

--- a/pyrogram/client/types/messages_and_media/document.py
+++ b/pyrogram/client/types/messages_and_media/document.py
@@ -18,6 +18,7 @@
 
 from struct import pack
 
+import pyrogram
 from pyrogram.api import types
 from .photo_size import PhotoSize
 from ..pyrogram_type import PyrogramType
@@ -49,9 +50,9 @@ class Document(PyrogramType):
 
     def __init__(self,
                  *,
-                 client,
+                 client: "pyrogram.Client",
                  file_id: str,
-                 thumb=None,
+                 thumb: PhotoSize = None,
                  file_name: str = None,
                  mime_type: str = None,
                  file_size: int = None,

--- a/pyrogram/client/types/messages_and_media/document.py
+++ b/pyrogram/client/types/messages_and_media/document.py
@@ -66,7 +66,7 @@ class Document(PyrogramType):
         self.date = date
 
     @staticmethod
-    def parse(client, document: types.Document, file_name: str) -> "Document":
+    def _parse(client, document: types.Document, file_name: str) -> "Document":
         return Document(
             file_id=encode(
                 pack(
@@ -77,7 +77,7 @@ class Document(PyrogramType):
                     document.access_hash
                 )
             ),
-            thumb=PhotoSize.parse(client, document.thumb),
+            thumb=PhotoSize._parse(client, document.thumb),
             file_name=file_name,
             mime_type=document.mime_type,
             file_size=document.size,

--- a/pyrogram/client/types/messages_and_media/location.py
+++ b/pyrogram/client/types/messages_and_media/location.py
@@ -38,7 +38,7 @@ class Location(PyrogramType):
         self.latitude = latitude
 
     @staticmethod
-    def parse(client, geo_point: types.GeoPoint) -> "Location":
+    def _parse(client, geo_point: types.GeoPoint) -> "Location":
         if isinstance(geo_point, types.GeoPoint):
             return Location(
                 longitude=geo_point.long,

--- a/pyrogram/client/types/messages_and_media/location.py
+++ b/pyrogram/client/types/messages_and_media/location.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+import pyrogram
+
 from pyrogram.api import types
 from ..pyrogram_type import PyrogramType
 
@@ -31,7 +33,11 @@ class Location(PyrogramType):
             Latitude as defined by sender.
     """
 
-    def __init__(self, *, client, longitude: float, latitude: float):
+    def __init__(self,
+                 *,
+                 client: "pyrogram.Client",
+                 longitude: float,
+                 latitude: float):
         super().__init__(client)
 
         self.longitude = longitude

--- a/pyrogram/client/types/messages_and_media/location.py
+++ b/pyrogram/client/types/messages_and_media/location.py
@@ -35,7 +35,7 @@ class Location(PyrogramType):
 
     def __init__(self,
                  *,
-                 client: "pyrogram.Client",
+                 client: "pyrogram.client.ext.BaseClient",
                  longitude: float,
                  latitude: float):
         super().__init__(client)

--- a/pyrogram/client/types/messages_and_media/message.py
+++ b/pyrogram/client/types/messages_and_media/message.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import List, Match, Union
+
 import pyrogram
 from pyrogram.api import types
 from pyrogram.api.errors import MessageIdsEmpty
@@ -201,18 +203,18 @@ class Message(PyrogramType):
 
         via_bot (:obj:`User <pyrogram.User>`):
             The information of the bot that generated the message from an inline query of a user.
-            
+
         outgoing (``bool``, *optional*):
             Whether the message is incoming or outgoing.
             Messages received from other chats are incoming (*outgoing* is False).
             Messages sent from yourself to other chats are outgoing (*outgoing* is True).
             An exception is made for your own personal chat; messages sent there will be incoming.
 
-        matches (``list``, *optional*):
+        matches (``List of regex Matches``, *optional*):
             A list containing all `Match Objects <https://docs.python.org/3/library/re.html#match-objects>`_ that match
             the text of this message. Only applicable when using :obj:`Filters.regex <pyrogram.Filters.regex>`.
 
-        command (``list``, *optional*):
+        command (``List of strings``, *optional*):
             A list containing the command and its arguments, if any.
             E.g.: "/start 1 2 3" would produce ["start", "1", "2", "3"].
             Only applicable when using :obj:`Filters.command <pyrogram.Filters.command>`.
@@ -226,57 +228,60 @@ class Message(PyrogramType):
 
     def __init__(self,
                  *,
-                 client,
+                 client: "pyrogram.Client",
                  message_id: int,
                  date: int = None,
-                 chat=None,
-                 from_user=None,
-                 forward_from=None,
-                 forward_from_chat=None,
+                 chat: Chat = None,
+                 from_user: User = None,
+                 forward_from: User = None,
+                 forward_from_chat: Chat = None,
                  forward_from_message_id: int = None,
                  forward_signature: str = None,
                  forward_date: int = None,
-                 reply_to_message=None,
-                 mentioned=None,
-                 empty=None,
-                 service=None,
-                 media=None,
+                 reply_to_message: "Message" = None,
+                 mentioned: bool = None,
+                 empty: bool = None,
+                 service: bool = None,
+                 media: bool = None,
                  edit_date: int = None,
                  media_group_id: str = None,
                  author_signature: str = None,
                  text: str = None,
-                 entities: list = None,
-                 caption_entities: list = None,
-                 audio=None,
-                 document=None,
-                 photo=None,
-                 sticker=None,
-                 animation=None,
-                 video=None,
-                 voice=None,
-                 video_note=None,
+                 entities: List["pyrogram.MessageEntity"] = None,
+                 caption_entities: List["pyrogram.MessageEntity"] = None,
+                 audio: "pyrogram.Audio" = None,
+                 document: "pyrogram.Document" = None,
+                 photo: "pyrogram.Photo" = None,
+                 sticker: "pyrogram.Sticker" = None,
+                 animation: "pyrogram.Animation" = None,
+                 video: "pyrogram.Video" = None,
+                 voice: "pyrogram.Voice" = None,
+                 video_note: "pyrogram.VideoNote" = None,
                  caption: str = None,
-                 contact=None,
-                 location=None,
-                 venue=None,
-                 web_page=None,
-                 new_chat_members: list = None,
-                 left_chat_member=None,
+                 contact: "pyrogram.Contact" = None,
+                 location: "pyrogram.Location" = None,
+                 venue: "pyrogram.Venue" = None,
+                 web_page: bool = None,
+                 new_chat_members: List[User] = None,
+                 left_chat_member: User = None,
                  new_chat_title: str = None,
-                 new_chat_photo=None,
+                 new_chat_photo: "pyrogram.Photo" = None,
                  delete_chat_photo: bool = None,
                  group_chat_created: bool = None,
                  supergroup_chat_created: bool = None,
                  channel_chat_created: bool = None,
                  migrate_to_chat_id: int = None,
                  migrate_from_chat_id: int = None,
-                 pinned_message=None,
+                 pinned_message: "Message" = None,
                  views: int = None,
-                 via_bot=None,
+                 via_bot: User = None,
                  outgoing: bool = None,
-                 matches: list = None,
-                 command: list = None,
-                 reply_markup=None):
+                 matches: List[Match] = None,
+                 command: List[str] = None,
+                 reply_markup: Union["pyrogram.InlineKeyboardMarkup",
+                                     "pyrogram.ReplyKeyboardMarkup",
+                                     "pyrogram.ReplyKeyboardRemove",
+                                     "pyrogram.ForceReply"] = None):
         super().__init__(client)
 
         self.message_id = message_id

--- a/pyrogram/client/types/messages_and_media/message.py
+++ b/pyrogram/client/types/messages_and_media/message.py
@@ -337,7 +337,7 @@ class Message(PyrogramType):
 
     @staticmethod
     def _parse(client, message: types.Message or types.MessageService or types.MessageEmpty, users: dict, chats: dict,
-              replies: int = 1):
+               replies: int = 1):
         if isinstance(message, types.MessageEmpty):
             return Message(message_id=message.id, empty=True, client=client)
 

--- a/pyrogram/client/types/messages_and_media/message.py
+++ b/pyrogram/client/types/messages_and_media/message.py
@@ -483,7 +483,7 @@ class Message(PyrogramType):
                             else:
                                 video = pyrogram.Video._parse(client, doc, video_attributes, file_name)
                         elif types.DocumentAttributeSticker in attributes:
-                            sticker = pyrogram.Sticker.parse(
+                            sticker = pyrogram.Sticker._parse(
                                 client, doc,
                                 attributes.get(types.DocumentAttributeImageSize, None),
                                 attributes[types.DocumentAttributeSticker],

--- a/pyrogram/client/types/messages_and_media/message.py
+++ b/pyrogram/client/types/messages_and_media/message.py
@@ -210,11 +210,11 @@ class Message(PyrogramType):
             Messages sent from yourself to other chats are outgoing (*outgoing* is True).
             An exception is made for your own personal chat; messages sent there will be incoming.
 
-        matches (``List of regex Matches``, *optional*):
+        matches (List of regex Matches, *optional*):
             A list containing all `Match Objects <https://docs.python.org/3/library/re.html#match-objects>`_ that match
             the text of this message. Only applicable when using :obj:`Filters.regex <pyrogram.Filters.regex>`.
 
-        command (``List of strings``, *optional*):
+        command (List of ``str``, *optional*):
             A list containing the command and its arguments, if any.
             E.g.: "/start 1 2 3" would produce ["start", "1", "2", "3"].
             Only applicable when using :obj:`Filters.command <pyrogram.Filters.command>`.
@@ -228,7 +228,7 @@ class Message(PyrogramType):
 
     def __init__(self,
                  *,
-                 client: "pyrogram.Client",
+                 client: "pyrogram.client.ext.BaseClient",
                  message_id: int,
                  date: int = None,
                  chat: Chat = None,

--- a/pyrogram/client/types/messages_and_media/message_entity.py
+++ b/pyrogram/client/types/messages_and_media/message_entity.py
@@ -78,7 +78,7 @@ class MessageEntity(PyrogramType):
         self.user = user
 
     @staticmethod
-    def parse(client, entity, users: dict) -> "MessageEntity" or None:
+    def _parse(client, entity, users: dict) -> "MessageEntity" or None:
         type = MessageEntity.ENTITIES.get(entity.ID, None)
 
         if type is None:
@@ -89,6 +89,6 @@ class MessageEntity(PyrogramType):
             offset=entity.offset,
             length=entity.length,
             url=getattr(entity, "url", None),
-            user=User.parse(client, users.get(getattr(entity, "user_id", None), None)),
+            user=User._parse(client, users.get(getattr(entity, "user_id", None), None)),
             client=client
         )

--- a/pyrogram/client/types/messages_and_media/message_entity.py
+++ b/pyrogram/client/types/messages_and_media/message_entity.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+import pyrogram
+
 from pyrogram.api import types
 from ..pyrogram_type import PyrogramType
 from ..user_and_chats.user import User
@@ -63,12 +65,12 @@ class MessageEntity(PyrogramType):
 
     def __init__(self,
                  *,
-                 client,
+                 client: "pyrogram.Client",
                  type: str,
                  offset: int,
                  length: int,
                  url: str = None,
-                 user=None):
+                 user: User = None):
         super().__init__(client)
 
         self.type = type

--- a/pyrogram/client/types/messages_and_media/message_entity.py
+++ b/pyrogram/client/types/messages_and_media/message_entity.py
@@ -65,7 +65,7 @@ class MessageEntity(PyrogramType):
 
     def __init__(self,
                  *,
-                 client: "pyrogram.Client",
+                 client: "pyrogram.client.ext.BaseClient",
                  type: str,
                  offset: int,
                  length: int,

--- a/pyrogram/client/types/messages_and_media/messages.py
+++ b/pyrogram/client/types/messages_and_media/messages.py
@@ -44,18 +44,18 @@ class Messages(PyrogramType):
         self.messages = messages
 
     @staticmethod
-    def parse(client, messages: types.messages.Messages) -> "Messages":
+    def _parse(client, messages: types.messages.Messages) -> "Messages":
         users = {i.id: i for i in messages.users}
         chats = {i.id: i for i in messages.chats}
 
         return Messages(
             total_count=getattr(messages, "count", len(messages.messages)),
-            messages=[Message.parse(client, message, users, chats) for message in messages.messages],
+            messages=[Message._parse(client, message, users, chats) for message in messages.messages],
             client=client
         )
 
     @staticmethod
-    def parse_deleted(client, update) -> "Messages":
+    def _parse_deleted(client, update) -> "Messages":
         messages = update.messages
         channel_id = getattr(update, "channel_id", None)
 

--- a/pyrogram/client/types/messages_and_media/messages.py
+++ b/pyrogram/client/types/messages_and_media/messages.py
@@ -38,7 +38,7 @@ class Messages(PyrogramType):
 
     def __init__(self,
                  *,
-                 client: "pyrogram.Client",
+                 client: "pyrogram.client.ext.BaseClient",
                  total_count: int,
                  messages: List[Message]):
         super().__init__(client)

--- a/pyrogram/client/types/messages_and_media/messages.py
+++ b/pyrogram/client/types/messages_and_media/messages.py
@@ -16,6 +16,9 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import List
+
+import pyrogram
 from pyrogram.api import types
 from .message import Message
 from ..pyrogram_type import PyrogramType
@@ -35,9 +38,9 @@ class Messages(PyrogramType):
 
     def __init__(self,
                  *,
-                 client,
+                 client: "pyrogram.Client",
                  total_count: int,
-                 messages: list):
+                 messages: List[Message]):
         super().__init__(client)
 
         self.total_count = total_count

--- a/pyrogram/client/types/messages_and_media/photo.py
+++ b/pyrogram/client/types/messages_and_media/photo.py
@@ -18,7 +18,9 @@
 
 from base64 import b64encode
 from struct import pack
+from typing import List
 
+import pyrogram
 from pyrogram.api import types
 from .photo_size import PhotoSize
 from ..pyrogram_type import PyrogramType
@@ -41,10 +43,10 @@ class Photo(PyrogramType):
 
     def __init__(self,
                  *,
-                 client,
+                 client: "pyrogram.Client",
                  id: str,
                  date: int,
-                 sizes: list):
+                 sizes: List[PhotoSize]):
         super().__init__(client)
 
         self.id = id

--- a/pyrogram/client/types/messages_and_media/photo.py
+++ b/pyrogram/client/types/messages_and_media/photo.py
@@ -52,7 +52,7 @@ class Photo(PyrogramType):
         self.sizes = sizes
 
     @staticmethod
-    def parse(client, photo: types.Photo):
+    def _parse(client, photo: types.Photo):
         if isinstance(photo, types.Photo):
             raw_sizes = photo.sizes
             sizes = []

--- a/pyrogram/client/types/messages_and_media/photo.py
+++ b/pyrogram/client/types/messages_and_media/photo.py
@@ -43,7 +43,7 @@ class Photo(PyrogramType):
 
     def __init__(self,
                  *,
-                 client: "pyrogram.Client",
+                 client: "pyrogram.client.ext.BaseClient",
                  id: str,
                  date: int,
                  sizes: List[PhotoSize]):

--- a/pyrogram/client/types/messages_and_media/photo_size.py
+++ b/pyrogram/client/types/messages_and_media/photo_size.py
@@ -43,7 +43,7 @@ class PhotoSize(PyrogramType):
 
     def __init__(self,
                  *,
-                 client: "pyrogram.Client",
+                 client: "pyrogram.client.ext.BaseClient",
                  file_id: str,
                  width: int,
                  height: int,

--- a/pyrogram/client/types/messages_and_media/photo_size.py
+++ b/pyrogram/client/types/messages_and_media/photo_size.py
@@ -18,6 +18,7 @@
 
 from struct import pack
 
+import pyrogram
 from pyrogram.api import types
 from pyrogram.client.ext.utils import encode
 from ..pyrogram_type import PyrogramType
@@ -42,7 +43,7 @@ class PhotoSize(PyrogramType):
 
     def __init__(self,
                  *,
-                 client,
+                 client: "pyrogram.Client",
                  file_id: str,
                  width: int,
                  height: int,

--- a/pyrogram/client/types/messages_and_media/photo_size.py
+++ b/pyrogram/client/types/messages_and_media/photo_size.py
@@ -55,7 +55,7 @@ class PhotoSize(PyrogramType):
         self.file_size = file_size
 
     @staticmethod
-    def parse(client, photo_size: types.PhotoSize or types.PhotoCachedSize):
+    def _parse(client, photo_size: types.PhotoSize or types.PhotoCachedSize):
         if isinstance(photo_size, (types.PhotoSize, types.PhotoCachedSize)):
 
             if isinstance(photo_size, types.PhotoSize):

--- a/pyrogram/client/types/messages_and_media/sticker.py
+++ b/pyrogram/client/types/messages_and_media/sticker.py
@@ -104,7 +104,7 @@ class Sticker(PyrogramType):
             return None
 
     @staticmethod
-    def parse(client, sticker: types.Document, image_size_attributes: types.DocumentAttributeImageSize,
+    def _parse(client, sticker: types.Document, image_size_attributes: types.DocumentAttributeImageSize,
               sticker_attributes: types.DocumentAttributeSticker, file_name: str) -> "Sticker":
         sticker_set = sticker_attributes.stickerset
 
@@ -126,7 +126,7 @@ class Sticker(PyrogramType):
             ),
             width=image_size_attributes.w if image_size_attributes else 0,
             height=image_size_attributes.h if image_size_attributes else 0,
-            thumb=PhotoSize.parse(client, sticker.thumb),
+            thumb=PhotoSize._parse(client, sticker.thumb),
             # TODO: mask_position
             set_name=set_name,
             emoji=sticker_attributes.alt or None,

--- a/pyrogram/client/types/messages_and_media/sticker.py
+++ b/pyrogram/client/types/messages_and_media/sticker.py
@@ -66,7 +66,7 @@ class Sticker(PyrogramType):
 
     def __init__(self,
                  *,
-                 client: "pyrogram.Client",
+                 client: "pyrogram.client.ext.BaseClient",
                  file_id: str,
                  width: int,
                  height: int,

--- a/pyrogram/client/types/messages_and_media/sticker.py
+++ b/pyrogram/client/types/messages_and_media/sticker.py
@@ -19,6 +19,7 @@
 from functools import lru_cache
 from struct import pack
 
+import pyrogram
 from pyrogram.api import types, functions
 from pyrogram.api.errors import StickersetInvalid
 from .photo_size import PhotoSize
@@ -65,18 +66,17 @@ class Sticker(PyrogramType):
 
     def __init__(self,
                  *,
-                 client,
+                 client: "pyrogram.Client",
                  file_id: str,
                  width: int,
                  height: int,
-                 thumb=None,
+                 thumb: PhotoSize = None,
                  file_name: str = None,
                  mime_type: str = None,
                  file_size: int = None,
                  date: int = None,
                  emoji: str = None,
-                 set_name: str = None,
-                 mask_position=None):
+                 set_name: str = None):
         super().__init__(client)
 
         self.file_id = file_id
@@ -89,7 +89,7 @@ class Sticker(PyrogramType):
         self.height = height
         self.emoji = emoji
         self.set_name = set_name
-        self.mask_position = mask_position
+        # self.mask_position = mask_position
 
     @staticmethod
     @lru_cache(maxsize=256)
@@ -105,7 +105,7 @@ class Sticker(PyrogramType):
 
     @staticmethod
     def _parse(client, sticker: types.Document, image_size_attributes: types.DocumentAttributeImageSize,
-              sticker_attributes: types.DocumentAttributeSticker, file_name: str) -> "Sticker":
+               sticker_attributes: types.DocumentAttributeSticker, file_name: str) -> "Sticker":
         sticker_set = sticker_attributes.stickerset
 
         if isinstance(sticker_set, types.InputStickerSetID):

--- a/pyrogram/client/types/messages_and_media/user_profile_photos.py
+++ b/pyrogram/client/types/messages_and_media/user_profile_photos.py
@@ -36,7 +36,7 @@ class UserProfilePhotos(PyrogramType):
 
     def __init__(self,
                  *,
-                 client: "pyrogram.Client",
+                 client: "pyrogram.client.ext.BaseClient",
                  total_count: int,
                  photos: List[Photo]):
         super().__init__(client)

--- a/pyrogram/client/types/messages_and_media/user_profile_photos.py
+++ b/pyrogram/client/types/messages_and_media/user_profile_photos.py
@@ -16,6 +16,9 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import List
+
+import pyrogram
 from .photo import Photo
 from ..pyrogram_type import PyrogramType
 
@@ -33,9 +36,9 @@ class UserProfilePhotos(PyrogramType):
 
     def __init__(self,
                  *,
-                 client,
+                 client: "pyrogram.Client",
                  total_count: int,
-                 photos: list):
+                 photos: List[Photo]):
         super().__init__(client)
 
         self.total_count = total_count

--- a/pyrogram/client/types/messages_and_media/user_profile_photos.py
+++ b/pyrogram/client/types/messages_and_media/user_profile_photos.py
@@ -42,9 +42,9 @@ class UserProfilePhotos(PyrogramType):
         self.photos = photos
 
     @staticmethod
-    def parse(client, photos) -> "UserProfilePhotos":
+    def _parse(client, photos) -> "UserProfilePhotos":
         return UserProfilePhotos(
             total_count=getattr(photos, "count", len(photos.photos)),
-            photos=[Photo.parse(client, photo) for photo in photos.photos],
+            photos=[Photo._parse(client, photo) for photo in photos.photos],
             client=client
         )

--- a/pyrogram/client/types/messages_and_media/venue.py
+++ b/pyrogram/client/types/messages_and_media/venue.py
@@ -60,9 +60,9 @@ class Venue(PyrogramType):
         self.foursquare_type = foursquare_type
 
     @staticmethod
-    def parse(client, venue: types.MessageMediaVenue):
+    def _parse(client, venue: types.MessageMediaVenue):
         return Venue(
-            location=Location.parse(client, venue.geo),
+            location=Location._parse(client, venue.geo),
             title=venue.title,
             address=venue.address,
             foursquare_id=venue.venue_id or None,

--- a/pyrogram/client/types/messages_and_media/venue.py
+++ b/pyrogram/client/types/messages_and_media/venue.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+import pyrogram
 from pyrogram.api import types
 from .location import Location
 from ..pyrogram_type import PyrogramType
@@ -45,8 +46,8 @@ class Venue(PyrogramType):
 
     def __init__(self,
                  *,
-                 client,
-                 location,
+                 client: "pyrogram.Client",
+                 location: Location,
                  title: str,
                  address: str,
                  foursquare_id: str = None,

--- a/pyrogram/client/types/messages_and_media/venue.py
+++ b/pyrogram/client/types/messages_and_media/venue.py
@@ -46,7 +46,7 @@ class Venue(PyrogramType):
 
     def __init__(self,
                  *,
-                 client: "pyrogram.Client",
+                 client: "pyrogram.client.ext.BaseClient",
                  location: Location,
                  title: str,
                  address: str,

--- a/pyrogram/client/types/messages_and_media/video.py
+++ b/pyrogram/client/types/messages_and_media/video.py
@@ -18,6 +18,7 @@
 
 from struct import pack
 
+import pyrogram
 from pyrogram.api import types
 from .photo_size import PhotoSize
 from ..pyrogram_type import PyrogramType
@@ -58,12 +59,12 @@ class Video(PyrogramType):
 
     def __init__(self,
                  *,
-                 client,
+                 client: "pyrogram.Client",
                  file_id: str,
                  width: int,
                  height: int,
                  duration: int,
-                 thumb=None,
+                 thumb: PhotoSize = None,
                  file_name: str = None,
                  mime_type: str = None,
                  file_size: int = None,
@@ -81,7 +82,8 @@ class Video(PyrogramType):
         self.duration = duration
 
     @staticmethod
-    def _parse(client, video: types.Document, video_attributes: types.DocumentAttributeVideo, file_name: str) -> "Video":
+    def _parse(client, video: types.Document, video_attributes: types.DocumentAttributeVideo,
+               file_name: str) -> "Video":
         return Video(
             file_id=encode(
                 pack(

--- a/pyrogram/client/types/messages_and_media/video.py
+++ b/pyrogram/client/types/messages_and_media/video.py
@@ -81,7 +81,7 @@ class Video(PyrogramType):
         self.duration = duration
 
     @staticmethod
-    def parse(client, video: types.Document, video_attributes: types.DocumentAttributeVideo, file_name: str) -> "Video":
+    def _parse(client, video: types.Document, video_attributes: types.DocumentAttributeVideo, file_name: str) -> "Video":
         return Video(
             file_id=encode(
                 pack(
@@ -95,7 +95,7 @@ class Video(PyrogramType):
             width=video_attributes.w,
             height=video_attributes.h,
             duration=video_attributes.duration,
-            thumb=PhotoSize.parse(client, video.thumb),
+            thumb=PhotoSize._parse(client, video.thumb),
             mime_type=video.mime_type,
             file_size=video.size,
             file_name=file_name,

--- a/pyrogram/client/types/messages_and_media/video.py
+++ b/pyrogram/client/types/messages_and_media/video.py
@@ -59,7 +59,7 @@ class Video(PyrogramType):
 
     def __init__(self,
                  *,
-                 client: "pyrogram.Client",
+                 client: "pyrogram.client.ext.BaseClient",
                  file_id: str,
                  width: int,
                  height: int,

--- a/pyrogram/client/types/messages_and_media/video_note.py
+++ b/pyrogram/client/types/messages_and_media/video_note.py
@@ -53,7 +53,7 @@ class VideoNote(PyrogramType):
 
     def __init__(self,
                  *,
-                 client: "pyrogram.Client",
+                 client: "pyrogram.client.ext.BaseClient",
                  file_id: str,
                  length: int,
                  duration: int,

--- a/pyrogram/client/types/messages_and_media/video_note.py
+++ b/pyrogram/client/types/messages_and_media/video_note.py
@@ -71,7 +71,7 @@ class VideoNote(PyrogramType):
         self.duration = duration
 
     @staticmethod
-    def parse(client, video_note: types.Document, video_attributes: types.DocumentAttributeVideo) -> "VideoNote":
+    def _parse(client, video_note: types.Document, video_attributes: types.DocumentAttributeVideo) -> "VideoNote":
         return VideoNote(
             file_id=encode(
                 pack(
@@ -84,7 +84,7 @@ class VideoNote(PyrogramType):
             ),
             length=video_attributes.w,
             duration=video_attributes.duration,
-            thumb=PhotoSize.parse(client, video_note.thumb),
+            thumb=PhotoSize._parse(client, video_note.thumb),
             file_size=video_note.size,
             mime_type=video_note.mime_type,
             date=video_note.date,

--- a/pyrogram/client/types/messages_and_media/video_note.py
+++ b/pyrogram/client/types/messages_and_media/video_note.py
@@ -18,6 +18,7 @@
 
 from struct import pack
 
+import pyrogram
 from pyrogram.api import types
 from .photo_size import PhotoSize
 from ..pyrogram_type import PyrogramType
@@ -52,11 +53,11 @@ class VideoNote(PyrogramType):
 
     def __init__(self,
                  *,
-                 client,
+                 client: "pyrogram.Client",
                  file_id: str,
                  length: int,
                  duration: int,
-                 thumb=None,
+                 thumb: PhotoSize = None,
                  mime_type: str = None,
                  file_size: int = None,
                  date: int = None):

--- a/pyrogram/client/types/messages_and_media/voice.py
+++ b/pyrogram/client/types/messages_and_media/voice.py
@@ -49,7 +49,7 @@ class Voice(PyrogramType):
 
     def __init__(self,
                  *,
-                 client: "pyrogram.Client",
+                 client: "pyrogram.client.ext.BaseClient",
                  file_id: str,
                  duration: int,
                  waveform: bytes = None,

--- a/pyrogram/client/types/messages_and_media/voice.py
+++ b/pyrogram/client/types/messages_and_media/voice.py
@@ -18,6 +18,7 @@
 
 from struct import pack
 
+import pyrogram
 from pyrogram.api import types
 from ..pyrogram_type import PyrogramType
 from ...ext.utils import encode
@@ -48,7 +49,7 @@ class Voice(PyrogramType):
 
     def __init__(self,
                  *,
-                 client,
+                 client: "pyrogram.Client",
                  file_id: str,
                  duration: int,
                  waveform: bytes = None,

--- a/pyrogram/client/types/messages_and_media/voice.py
+++ b/pyrogram/client/types/messages_and_media/voice.py
@@ -65,7 +65,7 @@ class Voice(PyrogramType):
         self.date = date
 
     @staticmethod
-    def parse(client, voice: types.Document, attributes: types.DocumentAttributeAudio) -> "Voice":
+    def _parse(client, voice: types.Document, attributes: types.DocumentAttributeAudio) -> "Voice":
         return Voice(
             file_id=encode(
                 pack(

--- a/pyrogram/client/types/pyrogram_type.py
+++ b/pyrogram/client/types/pyrogram_type.py
@@ -52,7 +52,7 @@ class Encoder(JSONEncoder):
 
         return remove_none(
             OrderedDict(
-                [("_", "pyrogram:" + o.__class__.__name__)]
+                [("_", "pyrogram." + o.__class__.__name__)]
                 + [i for i in content.items()]
             )
         )

--- a/pyrogram/client/types/user_and_chats/chat.py
+++ b/pyrogram/client/types/user_and_chats/chat.py
@@ -79,7 +79,7 @@ class Chat(PyrogramType):
 
     def __init__(self,
                  *,
-                 client: "pyrogram.Client",
+                 client: "pyrogram.client.ext.BaseClient",
                  id: int,
                  type: str,
                  title: str = None,

--- a/pyrogram/client/types/user_and_chats/chat.py
+++ b/pyrogram/client/types/user_and_chats/chat.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+import pyrogram
 from pyrogram.api import types
 from .chat_photo import ChatPhoto
 from ..pyrogram_type import PyrogramType
@@ -78,7 +79,7 @@ class Chat(PyrogramType):
 
     def __init__(self,
                  *,
-                 client,
+                 client: "pyrogram.Client",
                  id: int,
                  type: str,
                  title: str = None,
@@ -86,7 +87,7 @@ class Chat(PyrogramType):
                  first_name: str = None,
                  last_name: str = None,
                  all_members_are_administrators: bool = None,
-                 photo=None,
+                 photo: ChatPhoto = None,
                  description: str = None,
                  invite_link: str = None,
                  pinned_message=None,
@@ -175,7 +176,7 @@ class Chat(PyrogramType):
     @staticmethod
     def _parse_full(client, chat_full: types.messages.ChatFull or types.UserFull) -> "Chat":
         if isinstance(chat_full, types.UserFull):
-            _parsed_chat = Chat.parse_user_chat(client, chat_full.user)
+            parsed_chat = Chat._parse_user_chat(client, chat_full.user)
             parsed_chat.description = chat_full.about
         else:
             full_chat = chat_full.full_chat
@@ -186,12 +187,12 @@ class Chat(PyrogramType):
                     chat = i
 
             if isinstance(full_chat, types.ChatFull):
-                _parsed_chat = Chat.parse_chat_chat(client, chat)
+                parsed_chat = Chat._parse_chat_chat(client, chat)
 
                 if isinstance(full_chat.participants, types.ChatParticipants):
                     parsed_chat.members_count = len(full_chat.participants.participants)
             else:
-                _parsed_chat = Chat.parse_channel_chat(client, chat)
+                parsed_chat = Chat._parse_channel_chat(client, chat)
                 parsed_chat.members_count = full_chat.participants_count
                 parsed_chat.description = full_chat.about or None
                 # TODO: Add StickerSet type

--- a/pyrogram/client/types/user_and_chats/chat_member.py
+++ b/pyrogram/client/types/user_and_chats/chat_member.py
@@ -118,7 +118,7 @@ class ChatMember(PyrogramType):
         self.can_add_web_page_previews = can_add_web_page_previews
 
     @staticmethod
-    def parse(client, member, user) -> "ChatMember":
+    def _parse(client, member, user) -> "ChatMember":
         if isinstance(member, (types.ChannelParticipant, types.ChannelParticipantSelf, types.ChatParticipant)):
             return ChatMember(user=user, status="member", client=client)
 

--- a/pyrogram/client/types/user_and_chats/chat_member.py
+++ b/pyrogram/client/types/user_and_chats/chat_member.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+import pyrogram
+
 from pyrogram.api import types
 from ..pyrogram_type import PyrogramType
 
@@ -81,8 +83,8 @@ class ChatMember(PyrogramType):
 
     def __init__(self,
                  *,
-                 client,
-                 user,
+                 client: "pyrogram.Client",
+                 user: "pyrogram.User",
                  status: str,
                  until_date: int = None,
                  can_be_edited: bool = None,

--- a/pyrogram/client/types/user_and_chats/chat_member.py
+++ b/pyrogram/client/types/user_and_chats/chat_member.py
@@ -83,7 +83,7 @@ class ChatMember(PyrogramType):
 
     def __init__(self,
                  *,
-                 client: "pyrogram.Client",
+                 client: "pyrogram.client.ext.BaseClient",
                  user: "pyrogram.User",
                  status: str,
                  until_date: int = None,

--- a/pyrogram/client/types/user_and_chats/chat_member.py
+++ b/pyrogram/client/types/user_and_chats/chat_member.py
@@ -121,6 +121,8 @@ class ChatMember(PyrogramType):
 
     @staticmethod
     def _parse(client, member, user) -> "ChatMember":
+        user = pyrogram.User._parse(client, user)
+
         if isinstance(member, (types.ChannelParticipant, types.ChannelParticipantSelf, types.ChatParticipant)):
             return ChatMember(user=user, status="member", client=client)
 

--- a/pyrogram/client/types/user_and_chats/chat_members.py
+++ b/pyrogram/client/types/user_and_chats/chat_members.py
@@ -16,6 +16,9 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import List
+
+import pyrogram
 from pyrogram.api import types
 from .chat_member import ChatMember
 from .user import User
@@ -35,9 +38,9 @@ class ChatMembers(PyrogramType):
 
     def __init__(self,
                  *,
-                 client,
+                 client: "pyrogram.Client",
                  total_count: int,
-                 chat_members: list):
+                 chat_members: List[ChatMember]):
         super().__init__(client)
 
         self.total_count = total_count

--- a/pyrogram/client/types/user_and_chats/chat_members.py
+++ b/pyrogram/client/types/user_and_chats/chat_members.py
@@ -44,7 +44,7 @@ class ChatMembers(PyrogramType):
         self.chat_members = chat_members
 
     @staticmethod
-    def parse(client, members):
+    def _parse(client, members):
         users = {i.id: i for i in members.users}
         chat_members = []
 
@@ -56,8 +56,8 @@ class ChatMembers(PyrogramType):
             total_count = len(members)
 
         for member in members:
-            user = User.parse(client, users[member.user_id])
-            chat_members.append(ChatMember.parse(client, member, user))
+            user = User._parse(client, users[member.user_id])
+            chat_members.append(ChatMember._parse(client, member, user))
 
         return ChatMembers(
             total_count=total_count,

--- a/pyrogram/client/types/user_and_chats/chat_members.py
+++ b/pyrogram/client/types/user_and_chats/chat_members.py
@@ -38,7 +38,7 @@ class ChatMembers(PyrogramType):
 
     def __init__(self,
                  *,
-                 client: "pyrogram.Client",
+                 client: "pyrogram.client.ext.BaseClient",
                  total_count: int,
                  chat_members: List[ChatMember]):
         super().__init__(client)

--- a/pyrogram/client/types/user_and_chats/chat_photo.py
+++ b/pyrogram/client/types/user_and_chats/chat_photo.py
@@ -18,6 +18,7 @@
 
 from struct import pack
 
+import pyrogram
 from pyrogram.api import types
 from ..pyrogram_type import PyrogramType
 from ...ext.utils import encode
@@ -36,7 +37,7 @@ class ChatPhoto(PyrogramType):
 
     def __init__(self,
                  *,
-                 client,
+                 client: "pyrogram.Client",
                  small_file_id: str,
                  big_file_id: str):
         super().__init__(client)

--- a/pyrogram/client/types/user_and_chats/chat_photo.py
+++ b/pyrogram/client/types/user_and_chats/chat_photo.py
@@ -37,7 +37,7 @@ class ChatPhoto(PyrogramType):
 
     def __init__(self,
                  *,
-                 client: "pyrogram.Client",
+                 client: "pyrogram.client.ext.BaseClient",
                  small_file_id: str,
                  big_file_id: str):
         super().__init__(client)

--- a/pyrogram/client/types/user_and_chats/chat_photo.py
+++ b/pyrogram/client/types/user_and_chats/chat_photo.py
@@ -45,7 +45,7 @@ class ChatPhoto(PyrogramType):
         self.big_file_id = big_file_id
 
     @staticmethod
-    def parse(client, chat_photo: types.UserProfilePhoto or types.ChatPhoto):
+    def _parse(client, chat_photo: types.UserProfilePhoto or types.ChatPhoto):
         if not isinstance(chat_photo, (types.UserProfilePhoto, types.ChatPhoto)):
             return None
 

--- a/pyrogram/client/types/user_and_chats/dialog.py
+++ b/pyrogram/client/types/user_and_chats/dialog.py
@@ -63,7 +63,7 @@ class Dialog(PyrogramType):
         self.is_pinned = is_pinned
 
     @staticmethod
-    def parse(client, dialog, messages, users, chats) -> "Dialog":
+    def _parse(client, dialog, messages, users, chats) -> "Dialog":
         chat_id = dialog.peer
 
         if isinstance(chat_id, types.PeerUser):
@@ -74,7 +74,7 @@ class Dialog(PyrogramType):
             chat_id = int("-100" + str(chat_id.channel_id))
 
         return Dialog(
-            chat=Chat.parse_dialog(client, dialog.peer, users, chats),
+            chat=Chat._parse_dialog(client, dialog.peer, users, chats),
             top_message=messages.get(chat_id),
             unread_messages_count=dialog.unread_count,
             unread_mentions_count=dialog.unread_mentions_count,

--- a/pyrogram/client/types/user_and_chats/dialog.py
+++ b/pyrogram/client/types/user_and_chats/dialog.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+import pyrogram
+
 from pyrogram.api import types
 from ..pyrogram_type import PyrogramType
 from ..user_and_chats import Chat
@@ -46,9 +48,9 @@ class Dialog(PyrogramType):
 
     def __init__(self,
                  *,
-                 client,
-                 chat,
-                 top_message,
+                 client: "pyrogram.Client",
+                 chat: Chat,
+                 top_message: "pyrogram.Message",
                  unread_messages_count: int,
                  unread_mentions_count: int,
                  unread_mark: bool,

--- a/pyrogram/client/types/user_and_chats/dialog.py
+++ b/pyrogram/client/types/user_and_chats/dialog.py
@@ -48,7 +48,7 @@ class Dialog(PyrogramType):
 
     def __init__(self,
                  *,
-                 client: "pyrogram.Client",
+                 client: "pyrogram.client.ext.BaseClient",
                  chat: Chat,
                  top_message: "pyrogram.Message",
                  unread_messages_count: int,

--- a/pyrogram/client/types/user_and_chats/dialogs.py
+++ b/pyrogram/client/types/user_and_chats/dialogs.py
@@ -38,7 +38,7 @@ class Dialogs(PyrogramType):
 
     def __init__(self,
                  *,
-                 client: "pyrogram.Client",
+                 client: "pyrogram.client.ext.BaseClient",
                  total_count: int,
                  dialogs: List[Dialog]):
         super().__init__(client)

--- a/pyrogram/client/types/user_and_chats/dialogs.py
+++ b/pyrogram/client/types/user_and_chats/dialogs.py
@@ -44,7 +44,7 @@ class Dialogs(PyrogramType):
         self.dialogs = dialogs
 
     @staticmethod
-    def parse(client, dialogs) -> "Dialogs":
+    def _parse(client, dialogs) -> "Dialogs":
         users = {i.id: i for i in dialogs.users}
         chats = {i.id: i for i in dialogs.chats}
 
@@ -63,10 +63,10 @@ class Dialogs(PyrogramType):
             else:
                 chat_id = int("-100" + str(to_id.channel_id))
 
-            messages[chat_id] = Message.parse(client, message, users, chats)
+            messages[chat_id] = Message._parse(client, message, users, chats)
 
         return Dialogs(
             total_count=getattr(dialogs, "count", len(dialogs.dialogs)),
-            dialogs=[Dialog.parse(client, dialog, messages, users, chats) for dialog in dialogs.dialogs],
+            dialogs=[Dialog._parse(client, dialog, messages, users, chats) for dialog in dialogs.dialogs],
             client=client
         )

--- a/pyrogram/client/types/user_and_chats/dialogs.py
+++ b/pyrogram/client/types/user_and_chats/dialogs.py
@@ -16,6 +16,9 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import List
+
+import pyrogram
 from pyrogram.api import types
 from .dialog import Dialog
 from ..messages_and_media import Message
@@ -35,9 +38,9 @@ class Dialogs(PyrogramType):
 
     def __init__(self,
                  *,
-                 client,
+                 client: "pyrogram.Client",
                  total_count: int,
-                 dialogs: list):
+                 dialogs: List[Dialog]):
         super().__init__(client)
 
         self.total_count = total_count

--- a/pyrogram/client/types/user_and_chats/user.py
+++ b/pyrogram/client/types/user_and_chats/user.py
@@ -104,7 +104,7 @@ class User(PyrogramType):
         self.restriction_reason = restriction_reason
 
     @staticmethod
-    def parse(client, user: types.User) -> "User" or None:
+    def _parse(client, user: types.User) -> "User" or None:
         if user is None:
             return None
 
@@ -117,11 +117,11 @@ class User(PyrogramType):
             is_bot=user.bot,
             first_name=user.first_name,
             last_name=user.last_name,
-            status=UserStatus.parse(client, user.status, user.id, user.bot),
+            status=UserStatus._parse(client, user.status, user.id, user.bot),
             username=user.username,
             language_code=user.lang_code,
             phone_number=user.phone,
-            photo=ChatPhoto.parse(client, user.photo),
+            photo=ChatPhoto._parse(client, user.photo),
             restriction_reason=user.restriction_reason,
             client=client
         )

--- a/pyrogram/client/types/user_and_chats/user.py
+++ b/pyrogram/client/types/user_and_chats/user.py
@@ -72,7 +72,7 @@ class User(PyrogramType):
 
     def __init__(self,
                  *,
-                 client: "pyrogram.Client",
+                 client: "pyrogram.client.ext.BaseClient",
                  id: int,
                  is_self: bool,
                  is_contact: bool,

--- a/pyrogram/client/types/user_and_chats/user.py
+++ b/pyrogram/client/types/user_and_chats/user.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+import pyrogram
 from pyrogram.api import types
 from .chat_photo import ChatPhoto
 from .user_status import UserStatus
@@ -71,7 +72,7 @@ class User(PyrogramType):
 
     def __init__(self,
                  *,
-                 client,
+                 client: "pyrogram.Client",
                  id: int,
                  is_self: bool,
                  is_contact: bool,
@@ -80,11 +81,11 @@ class User(PyrogramType):
                  is_bot: bool,
                  first_name: str,
                  last_name: str = None,
-                 status=None,
+                 status: UserStatus = None,
                  username: str = None,
                  language_code: str = None,
                  phone_number: str = None,
-                 photo=None,
+                 photo: ChatPhoto = None,
                  restriction_reason: str = None):
         super().__init__(client)
 

--- a/pyrogram/client/types/user_and_chats/user_status.py
+++ b/pyrogram/client/types/user_and_chats/user_status.py
@@ -66,7 +66,7 @@ class UserStatus(PyrogramType):
 
     def __init__(self,
                  *,
-                 client: "pyrogram.Client",
+                 client: "pyrogram.client.ext.BaseClient",
                  user_id: int,
                  online: bool = None,
                  offline: bool = None,

--- a/pyrogram/client/types/user_and_chats/user_status.py
+++ b/pyrogram/client/types/user_and_chats/user_status.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+import pyrogram
+
 from pyrogram.api import types
 from ..pyrogram_type import PyrogramType
 
@@ -64,7 +66,7 @@ class UserStatus(PyrogramType):
 
     def __init__(self,
                  *,
-                 client,
+                 client: "pyrogram.Client",
                  user_id: int,
                  online: bool = None,
                  offline: bool = None,

--- a/pyrogram/client/types/user_and_chats/user_status.py
+++ b/pyrogram/client/types/user_and_chats/user_status.py
@@ -85,7 +85,7 @@ class UserStatus(PyrogramType):
         self.long_time_ago = long_time_ago
 
     @staticmethod
-    def parse(client, user_status, user_id: int, is_bot: bool = False):
+    def _parse(client, user_status, user_id: int, is_bot: bool = False):
         if is_bot:
             return None
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pyaes==1.6.1
 pysocks==1.6.8
+typing==3.6.6


### PR DESCRIPTION
This PR will add `typing` as backported requirement package (for Python 3.4 only, in 3.5+ this is in the stdlib already and thus simply ignored).

Hints all around Pyrogram types and methods are added as well. 