### PR TITLE
Add bot_token argument

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ It enables you to easily create custom apps using both user and bot identities (
 
     `Pyrogram in fully-asynchronous mode is also available » <https://github.com/pyrogram/pyrogram/issues/181>`_
     
-    `Working PoC of Telegram voice calls using Pyrogram » <https://github.com/bakatrouble/pylibtgvoip>`_
+    `Working PoC of Telegram voice calls using Pyrogram » <https://github.com/bakatrouble/pytgvoip>`_
 
 Features
 --------

--- a/pyrogram/client/client.py
+++ b/pyrogram/client/client.py
@@ -293,6 +293,7 @@ class Client(Methods, BaseClient):
         try:
             if self.user_id is None:
                 if self.bot_token is None:
+                    self.is_bot = False
                     self.authorize_user()
                 else:
                     self.is_bot = True

--- a/pyrogram/client/client.py
+++ b/pyrogram/client/client.py
@@ -29,6 +29,7 @@ import struct
 import tempfile
 import threading
 import time
+import warnings
 from configparser import ConfigParser
 from datetime import datetime
 from hashlib import sha256, md5
@@ -67,9 +68,8 @@ class Client(Methods, BaseClient):
 
     Args:
         session_name (``str``):
-            Name to uniquely identify a session of either a User or a Bot.
-            For Users: pass a string of your choice, e.g.: "my_main_account".
-            For Bots: pass your Bot API token, e.g.: "123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11"
+            Name to uniquely identify a session of either a User or a Bot, e.g.: "my_main_account".
+            You still can use bot token here, but it will be deprecated in next release.
             Note: as long as a valid User session file exists, Pyrogram won't ask you again to input your phone number.
 
         api_id (``int``, *optional*):
@@ -144,6 +144,10 @@ class Client(Methods, BaseClient):
             a new Telegram account in case the phone number you passed is not registered yet.
             Only applicable for new sessions.
 
+        bot_token (``str``, *optional*):
+            Pass your Bot API token to create a bot session, e.g.: "123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11"
+            Only applicable for new sessions.
+
         last_name (``str``, *optional*):
             Same purpose as *first_name*; pass a Last Name to avoid entering it manually. It can
             be an empty string: "". Only applicable for new sessions.
@@ -192,6 +196,7 @@ class Client(Methods, BaseClient):
                  password: str = None,
                  recovery_code: callable = None,
                  force_sms: bool = False,
+                 bot_token: str = None,
                  first_name: str = None,
                  last_name: str = None,
                  workers: int = BaseClient.WORKERS,
@@ -218,6 +223,7 @@ class Client(Methods, BaseClient):
         self.password = password
         self.recovery_code = recovery_code
         self.force_sms = force_sms
+        self.bot_token = bot_token
         self.first_name = first_name
         self.last_name = last_name
         self.workers = workers
@@ -263,8 +269,13 @@ class Client(Methods, BaseClient):
             raise ConnectionError("Client has already been started")
 
         if self.BOT_TOKEN_RE.match(self.session_name):
+            self.is_bot = True
             self.bot_token = self.session_name
             self.session_name = self.session_name.split(":")[0]
+            warnings.warn('\nYou are using a bot token as session name.\n'
+                          'It will be deprecated in next update, please use session file name to load '
+                          'existing sessions and bot_token argument to create new sessions.',
+                          DeprecationWarning, stacklevel=2)
 
         self.load_config()
         self.load_session()
@@ -284,11 +295,12 @@ class Client(Methods, BaseClient):
                 if self.bot_token is None:
                     self.authorize_user()
                 else:
+                    self.is_bot = True
                     self.authorize_bot()
 
                 self.save_session()
 
-            if self.bot_token is None:
+            if not self.is_bot:
                 if self.takeout:
                     self.takeout_id = self.send(functions.account.InitTakeoutSession()).id
                     log.warning("Takeout session {} initiated".format(self.takeout_id))
@@ -1113,6 +1125,8 @@ class Client(Methods, BaseClient):
             self.auth_key = base64.b64decode("".join(s["auth_key"]))
             self.user_id = s["user_id"]
             self.date = s.get("date", 0)
+            # TODO: replace default with False once token session name will be deprecated
+            self.is_bot = s.get("is_bot", self.is_bot)
 
             for k, v in s.get("peers_by_id", {}).items():
                 self.peers_by_id[int(k)] = utils.get_input_peer(int(k), v)
@@ -1246,7 +1260,8 @@ class Client(Methods, BaseClient):
                     test_mode=self.test_mode,
                     auth_key=auth_key,
                     user_id=self.user_id,
-                    date=self.date
+                    date=self.date,
+                    is_bot=self.is_bot,
                 ),
                 f,
                 indent=4

--- a/pyrogram/client/ext/base_client.py
+++ b/pyrogram/client/ext/base_client.py
@@ -68,7 +68,7 @@ class BaseClient:
     }
 
     def __init__(self):
-        self.is_bot = False
+        self.is_bot = None
         self.dc_id = None
         self.auth_key = None
         self.user_id = None

--- a/pyrogram/client/ext/base_client.py
+++ b/pyrogram/client/ext/base_client.py
@@ -68,7 +68,7 @@ class BaseClient:
     }
 
     def __init__(self):
-        self.bot_token = None
+        self.is_bot = False
         self.dc_id = None
         self.auth_key = None
         self.user_id = None

--- a/pyrogram/client/ext/syncer.py
+++ b/pyrogram/client/ext/syncer.py
@@ -94,6 +94,7 @@ class Syncer:
                 auth_key=auth_key,
                 user_id=client.user_id,
                 date=int(time.time()),
+                is_bot=client.is_bot,
                 peers_by_id={
                     k: getattr(v, "access_hash", None)
                     for k, v in client.peers_by_id.copy().items()


### PR DESCRIPTION
Closes #123.
Old behavior (bot token as session name) is still remaining with warning, but should be removed in future