### PR TITLE
A global fix for Python < v3.5.6 which was causing error with sqlite3

### DIFF
--- a/pyrogram/__init__.py
+++ b/pyrogram/__init__.py
@@ -18,6 +18,13 @@
 
 import sys
 
+if sys.version_info[:3] in [(3, 5, 0), (3, 5, 1), (3, 5, 2)]:
+    from .vendor import typing
+
+    # Monkey patch the standard "typing" module because Python versions from 3.5.0 to 3.5.2 have a broken one.
+    sys.modules["typing"] = typing
+
+
 __version__ = "0.12.0.develop"
 __license__ = "GNU Lesser General Public License v3 or later (LGPLv3+)"
 __copyright__ = "Copyright (C) 2017-2019 Dan Tès <https://github.com/delivrance>".replace(
@@ -28,9 +35,3 @@ from .errors import RPCError
 from .client import *
 from .client.handlers import *
 from .client.types import *
-
-if sys.version_info[:3] in [(3, 5, 0), (3, 5, 1), (3, 5, 2)]:
-    from .vendor import typing
-
-    # Monkey patch the standard "typing" module because Python versions from 3.5.0 to 3.5.2 have a broken one.
-    sys.modules["typing"] = typing


### PR DESCRIPTION
### I am giving no guarantee whether it will work for all

@delivrance  after trying so many ways to get through this, i finally solved the issue by replacing the typing from your source with mine.

i had to add a little tweaks to make it work.

**Nature of the issue**

After the last push on GitHub, my bot automatically updated and all of a sudden it was raising lots and lots of errors which got me confused

I had to disable all imports and the only one that was conflicting was sqlite3 modeule.

**Files Modified**

`pyrogram\vendor\typing`
`pyrogram/vendor/__init__.py`


That was the little contribution i could make so far.

if you see a more suitable title to give to this don't hesitate 




