### PR TITLE
Try/except handler.check()

### DIFF
--- a/pyrogram/client/ext/dispatcher.py
+++ b/pyrogram/client/ext/dispatcher.py
@@ -166,8 +166,13 @@ class Dispatcher:
                             args = None
 
                             if isinstance(handler, handler_type):
-                                if handler.check(parsed_update):
-                                    args = (parsed_update,)
+                                try:
+                                    if handler.check(parsed_update):
+                                        args = (parsed_update,)
+                                except Exception as e:
+                                    log.error(e, exc_info=True)
+                                    continue
+
                             elif isinstance(handler, RawUpdateHandler):
                                 args = (update, users, chats)
 


### PR DESCRIPTION
Previously, when handler.check raised errors, it would be excepted by the try on line 153, and would fail to loop through the rest of the groups/handlers.