### PR TITLE
Added support for bot_token inside config.ini file

### DIFF
--- a/pyrogram/client/client.py
+++ b/pyrogram/client/client.py
@@ -110,6 +110,7 @@ class Client(Methods, BaseClient):
         bot_token (``str``, *optional*):
             Pass your Bot API token to create a bot session, e.g.: "123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11"
             Only applicable for new sessions.
+            This is an alternative way to set it if you don't want to use the *config.ini* file.
 
         phone_number (``str`` | ``callable``, *optional*):
             Pass your phone number as string (with your Country Code prefix included) to avoid entering it manually.
@@ -1228,6 +1229,11 @@ class Client(Methods, BaseClient):
     def load_config(self):
         parser = ConfigParser()
         parser.read(str(self.config_file))
+        
+        if self.bot_token:
+            pass
+        else:
+            self.bot_token = parser.get("pyrogram", "bot_token", fallback=None)
 
         if self.api_id and self.api_hash:
             pass


### PR DESCRIPTION
If 'bot_token' is explicitly defined, than that is used, otherwise if there is a bot token in the config.ini file that is used.
bot_token is set to None if not present