### PR TITLE
Remove python-dev from docs for Termux

### DIFF
--- a/docs/source/topics/tgcrypto.rst
+++ b/docs/source/topics/tgcrypto.rst
@@ -24,7 +24,7 @@ what you should do next:
 -  **Windows**: Install `Visual C++ 2015 Build Tools <http://landinghub.visualstudio.com/visual-cpp-build-tools>`_.
 -  **macOS**: A pop-up will automatically ask you to install the command line developer tools.
 -  **Linux**: Install a proper C compiler (``gcc``, ``clang``) and the Python header files (``python3-dev``).
--  **Termux (Android)**: Install ``clang`` and ``python-dev`` packages.
+-  **Termux (Android)**: Install ``clang`` package.
 
 .. _TgCrypto: https://github.com/pyrogram/tgcrypto
 


### PR DESCRIPTION
Recently Termux removed all -dev packages and merged them to the main packages.

```
$ apt install python-dev
Reading package lists... Done
Building dependency tree
Reading state information... Done
Package python-dev is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However the following packages replace it:
  python

E: Package 'python-dev' has no installation candidate
```

So installing the `python` package now installs the header files also.