### PR TITLE
Add file_name param to file-related functions

### DIFF
--- a/pyrogram/client/methods/messages/send_animation.py
+++ b/pyrogram/client/methods/messages/send_animation.py
@@ -37,6 +37,7 @@ class SendAnimation(BaseClient):
         width: int = 0,
         height: int = 0,
         thumb: str = None,
+        file_name: str = None,
         disable_notification: bool = None,
         reply_to_message_id: int = None,
         reply_markup: Union[
@@ -90,6 +91,10 @@ class SendAnimation(BaseClient):
                 The thumbnail should be in JPEG format and less than 200 KB in size.
                 A thumbnail's width and height should not exceed 320 pixels.
                 Thumbnails can't be reused and can be only uploaded as a new file.
+
+            file_name (``str``, *optional*):
+                File name of the animation sent.
+                Defaults to file's path basename.
 
             disable_notification (``bool``, *optional*):
                 Sends the message silently.
@@ -163,7 +168,7 @@ class SendAnimation(BaseClient):
                             w=width,
                             h=height
                         ),
-                        types.DocumentAttributeFilename(file_name=os.path.basename(animation)),
+                        types.DocumentAttributeFilename(file_name=file_name or os.path.basename(animation)),
                         types.DocumentAttributeAnimated()
                     ]
                 )

--- a/pyrogram/client/methods/messages/send_audio.py
+++ b/pyrogram/client/methods/messages/send_audio.py
@@ -36,6 +36,7 @@ class SendAudio(BaseClient):
         performer: str = None,
         title: str = None,
         thumb: str = None,
+        file_name: str = None,
         disable_notification: bool = None,
         reply_to_message_id: int = None,
         reply_markup: Union[
@@ -87,6 +88,10 @@ class SendAudio(BaseClient):
                 The thumbnail should be in JPEG format and less than 200 KB in size.
                 A thumbnail's width and height should not exceed 320 pixels.
                 Thumbnails can't be reused and can be only uploaded as a new file.
+
+            file_name (``str``, *optional*):
+                File name of the audio sent.
+                Defaults to file's path basename.
 
             disable_notification (``bool``, *optional*):
                 Sends the message silently.
@@ -162,7 +167,7 @@ class SendAudio(BaseClient):
                             performer=performer,
                             title=title
                         ),
-                        types.DocumentAttributeFilename(file_name=os.path.basename(audio))
+                        types.DocumentAttributeFilename(file_name=file_name or os.path.basename(audio))
                     ]
                 )
             elif audio.startswith("http"):

--- a/pyrogram/client/methods/messages/send_document.py
+++ b/pyrogram/client/methods/messages/send_document.py
@@ -33,6 +33,7 @@ class SendDocument(BaseClient):
         thumb: str = None,
         caption: str = "",
         parse_mode: Union[str, None] = object,
+        file_name: str = None,
         disable_notification: bool = None,
         reply_to_message_id: int = None,
         reply_markup: Union[
@@ -73,6 +74,10 @@ class SendDocument(BaseClient):
                 Pass "markdown" or "md" to enable Markdown-style parsing only.
                 Pass "html" to enable HTML-style parsing only.
                 Pass None to completely disable style parsing.
+
+            file_name (``str``, *optional*):
+                File name of the document sent.
+                Defaults to file's path basename.
 
             disable_notification (``bool``, *optional*):
                 Sends the message silently.
@@ -137,7 +142,7 @@ class SendDocument(BaseClient):
                     file=file,
                     thumb=thumb,
                     attributes=[
-                        types.DocumentAttributeFilename(file_name=os.path.basename(document))
+                        types.DocumentAttributeFilename(file_name=file_name or os.path.basename(document))
                     ]
                 )
             elif document.startswith("http"):

--- a/pyrogram/client/methods/messages/send_video.py
+++ b/pyrogram/client/methods/messages/send_video.py
@@ -36,6 +36,7 @@ class SendVideo(BaseClient):
         width: int = 0,
         height: int = 0,
         thumb: str = None,
+        file_name: str = None,
         supports_streaming: bool = True,
         disable_notification: bool = None,
         reply_to_message_id: int = None,
@@ -86,6 +87,10 @@ class SendVideo(BaseClient):
                 The thumbnail should be in JPEG format and less than 200 KB in size.
                 A thumbnail's width and height should not exceed 320 pixels.
                 Thumbnails can't be reused and can be only uploaded as a new file.
+
+            file_name (``str``, *optional*):
+                File name of the video sent.
+                Defaults to file's path basename.
 
             supports_streaming (``bool``, *optional*):
                 Pass True, if the uploaded video is suitable for streaming.
@@ -160,7 +165,7 @@ class SendVideo(BaseClient):
                             w=width,
                             h=height
                         ),
-                        types.DocumentAttributeFilename(file_name=os.path.basename(video))
+                        types.DocumentAttributeFilename(file_name=file_name or os.path.basename(video))
                     ]
                 )
             elif video.startswith("http"):


### PR DESCRIPTION
Simple but useful changes for file-related send_* functions. Sometimes it need to send a file with specific filename, and not with its path basename. It's simpler and better to pass just a string instead of renaming original file.