### PR TITLE
support None as config_file to avoid trying to read any file

### DIFF
--- a/pyrogram/client/client.py
+++ b/pyrogram/client/client.py
@@ -157,7 +157,7 @@ class Client(Methods, BaseClient):
             where Pyrogram will store your session files. Defaults to the parent directory of the main script.
 
         config_file (``str``, *optional*):
-            Path of the configuration file. Defaults to ./config.ini
+            Path of the configuration file, or None to avoid trying to read one. Defaults to ./config.ini
 
         plugins (``dict``, *optional*):
             Your Smart Plugins settings as dict, e.g.: *dict(root="plugins")*.
@@ -240,7 +240,7 @@ class Client(Methods, BaseClient):
         self.last_name = last_name
         self.workers = workers
         self.workdir = Path(workdir)
-        self.config_file = Path(config_file)
+        self.config_file = Path(config_file) if config_file is not None else None
         self.plugins = plugins
         self.no_updates = no_updates
         self.takeout = takeout
@@ -1228,7 +1228,8 @@ class Client(Methods, BaseClient):
 
     def load_config(self):
         parser = ConfigParser()
-        parser.read(str(self.config_file))
+        if self.config_file:
+            parser.read(str(self.config_file))
 
         if self.bot_token:
             pass


### PR DESCRIPTION
There is currently no way to avoid trying to read a `config_file` because in the `Client` constructor the relevant parameter gets immediately passed through `pathlib.Path()`and then on to `ConfigParser().read()`.

This PR adds support for `Client(config_file=None)` to avoid trying to read anything.