### PR TITLE
fixed memory leak when session.send coroutine is cancelled

### DIFF
--- a/pyrogram/session/session.py
+++ b/pyrogram/session/session.py
@@ -385,8 +385,8 @@ class Session:
                 await asyncio.wait_for(self.results[msg_id].event.wait(), timeout)
             except asyncio.TimeoutError:
                 pass
-
-            result = self.results.pop(msg_id).value
+            finally:
+                result = self.results.pop(msg_id).value
 
             if result is None:
                 raise TimeoutError


### PR DESCRIPTION
added that when session.send coroutine is cancelled (or if any other exception is raised) the result should still be removed from the results list 

(#304 will be closed. merge this instead)