### PR TITLE
Fix RPCError 400 QUIZ_CORRECT_ANSWER_EMPTY

### DIFF
--- a/pyrogram/client/methods/messages/send_poll.py
+++ b/pyrogram/client/methods/messages/send_poll.py
@@ -110,7 +110,7 @@ class SendPoll(BaseClient):
                         public_voters=not is_anonymous or None,
                         quiz=type == "quiz" or None
                     ),
-                    correct_answers=[bytes([correct_option_id])] if correct_option_id else None
+                    correct_answers=[bytes([correct_option_id])] if not correct_option_id == None else None
                 ),
                 message="",
                 silent=disable_notification or None,

--- a/pyrogram/client/methods/messages/send_poll.py
+++ b/pyrogram/client/methods/messages/send_poll.py
@@ -110,7 +110,7 @@ class SendPoll(BaseClient):
                         public_voters=not is_anonymous or None,
                         quiz=type == "quiz" or None
                     ),
-                    correct_answers=[bytes([correct_option_id])] if not correct_option_id == None else None
+                    correct_answers=None if correct_option_id is None else [bytes([correct_option_id])]
                 ),
                 message="",
                 silent=disable_notification or None,


### PR DESCRIPTION
If correct_option_id == 0 then None is sent instead of 0