### PR TITLE
Update MTProto vs BotAPI - Download/upload section

### DIFF
--- a/docs/source/topics/mtproto-vs-botapi.rst
+++ b/docs/source/topics/mtproto-vs-botapi.rst
@@ -56,7 +56,7 @@ HTTP Bot API. Using Pyrogram you can:
     :columns: 1
 
     - :guilabel:`+` **Upload & download any file, up to 1500 MB each (~1.5 GB)**
-    - :guilabel:`--` The Bot API allows uploads and downloads of files only up to 50 MB / 20 MB in size (respectively).
+    - :guilabel:`--` The Bot API only allows uploads and downloads of files up to 20 MB.
 
 .. hlist::
     :columns: 1


### PR DESCRIPTION
Based on the recent changes on Telegram API (https://core.telegram.org/bots/api#getfile), bots can now download and upload files up to 20MB. Then Pyrogram docs have to change.