### PR TITLE
Relative path error

### DIFF
--- a/pyrogram/client/client.py
+++ b/pyrogram/client/client.py
@@ -201,7 +201,6 @@ class Client(Methods, BaseClient):
         self.workers = workers
         self.workdir = Path(workdir)
         self.config_file = Path(config_file).resolve()
-        print('---' + self.config_file + '---')
         self.plugins = plugins
         self.no_updates = no_updates
         self.takeout = takeout

--- a/pyrogram/client/client.py
+++ b/pyrogram/client/client.py
@@ -200,7 +200,8 @@ class Client(Methods, BaseClient):
         self.force_sms = force_sms
         self.workers = workers
         self.workdir = Path(workdir)
-        self.config_file = Path(config_file)
+        self.config_file = Path(config_file).resolve()
+        print('---' + self.config_file + '---')
         self.plugins = plugins
         self.no_updates = no_updates
         self.takeout = takeout

--- a/pyrogram/client/ext/base_client.py
+++ b/pyrogram/client/ext/base_client.py
@@ -56,7 +56,7 @@ class BaseClient:
     OFFLINE_SLEEP = 900
     WORKERS = 4
     WORKDIR = PARENT_DIR
-    CONFIG_FILE = PARENT_DIR / "config.ini"
+    CONFIG_FILE = "config.ini"
 
     PARSE_MODES = ["combined", "markdown", "md", "html", None]
 


### PR DESCRIPTION
When a script is run from a directory other than its parent, it cannot find the config.ini. With these small changes it seems to work