### PR TITLE
self.first_name as string for mention format

### DIFF
--- a/pyrogram/client/types/user_and_chats/user.py
+++ b/pyrogram/client/types/user_and_chats/user.py
@@ -160,7 +160,7 @@ class User(Object, Update):
 
     def __format__(self, format_spec):
         if format_spec == "mention":
-            return '<a href="tg://user?id={0}">{1}</a>'.format(self.id, html.escape(self.first_name))
+            return '<a href="tg://user?id={0}">{1}</a>'.format(self.id, html.escape(str(self.first_name)))
 
         return html.escape(str(self))
 


### PR DESCRIPTION
```await message.reply("\n".join(map(lambda x: f"{x.user:mention}", list(u for u in await client.get_chat_members(message.chat.id, filter="administrators") if not u.user.is_deleted))), parse_mode='HTML')```
causing **AttributeError: 'NoneType' object has no attribute 'replace'**

```
Traceback (most recent call last):
  File "<string>", line 2, in tmp
  File "<string>", line 2, in <lambda>
  File "/usr/local/lib/python3.8/dist-packages/pyrogram/client/types/user_and_chats/user.py", line 163, in format
    return '<a href="tg://user?id={0}">{1}</a>'.format(self.id, html.escape(self.first_name))
  File "/usr/lib/python3.8/html/init.py", line 19, in escape
    s = s.replace("&", "&") # Must be done first!
AttributeError: 'NoneType' object has no attribute 'replace'
```