### PR TITLE
Send a warning instead throwing an exeption when message type is not …

### DIFF
--- a/pyrogram/client/types/messages_and_media/message.py
+++ b/pyrogram/client/types/messages_and_media/message.py
@@ -2687,9 +2687,9 @@ class Message(Object, Update):
         """
         if as_copy:
             if self.service:
-                log.warning("Unable to copy service messages, message_id: {} from chat.id: {}".format(self.message_id, self.chat.id))
+                log.warning(f"Service messages cannot be copied. chat_id: {self.chat.id}, message_id: {self.message_id}")
             elif self.game and not self._client.is_bot:
-                log.warning("Users cannot send messages with Game media type, message_id: {} from chat.id: {}".format(self.message_id, self.chat.id))
+                log.warning(f"Users cannot send messages with Game media type. chat_id: {self.chat.id}, message_id: {self.message_id}")
             elif self.text:
                 return self._client.send_message(
                     chat_id,

--- a/pyrogram/client/types/messages_and_media/message.py
+++ b/pyrogram/client/types/messages_and_media/message.py
@@ -2687,9 +2687,9 @@ class Message(Object, Update):
         """
         if as_copy:
             if self.service:
-                log.warning("Unable to copy service messages, message_id: {}".format(self.message_id))
+                log.warning("Unable to copy service messages, message_id: {} from chat.id: {}".format(self.message_id, self.chat.id))
             elif self.game and not self._client.is_bot:
-                log.warning("Users cannot send messages with Game media type, message_id: {}".format(self.message_id))
+                log.warning("Users cannot send messages with Game media type, message_id: {} from chat.id: {}".format(self.message_id, self.chat.id))
             elif self.text:
                 return self._client.send_message(
                     chat_id,

--- a/pyrogram/client/types/messages_and_media/message.py
+++ b/pyrogram/client/types/messages_and_media/message.py
@@ -18,6 +18,7 @@
 
 from functools import partial
 from typing import List, Match, Union
+import logging
 
 import pyrogram
 from pyrogram.api import types
@@ -33,6 +34,8 @@ from ..user_and_chats.chat import Chat
 from ..user_and_chats.user import User
 from ...ext import utils
 from ...parser import utils as parser_utils, Parser
+
+log = logging.getLogger(__name__)
 
 
 class Str(str):
@@ -2684,12 +2687,10 @@ class Message(Object, Update):
         """
         if as_copy:
             if self.service:
-                raise ValueError("Unable to copy service messages")
-
-            if self.game and not self._client.is_bot:
-                raise ValueError("Users cannot send messages with Game media type")
-
-            if self.text:
+                log.warning("Unable to copy service messages, message_id: {}".format(self.message_id))
+            elif self.game and not self._client.is_bot:
+                log.warning("Users cannot send messages with Game media type, message_id: {}".format(self.message_id))
+            elif self.text:
                 return self._client.send_message(
                     chat_id,
                     text=self.text.html,


### PR DESCRIPTION
…compatible with as_copy
As messages copies are often done in batches, send a warning and continue the work is a far better behavior (so much user friendly).