### PR TITLE
__repr__ raises AttributeError: 'int' object has no attribute 'QUALNAME'

### DIFF
--- a/pyrogram/api/core/tl_object.py
+++ b/pyrogram/api/core/tl_object.py
@@ -53,6 +53,8 @@ class TLObject:
         return dumps(self, indent=4, default=TLObject.default, ensure_ascii=False)
 
     def __repr__(self) -> str:
+        if not hasattr(self, "QUALNAME"):
+            return repr(self)
         return "pyrogram.api.{}({})".format(
             self.QUALNAME,
             ", ".join(


### PR DESCRIPTION
`repr`-ing a "`pyrogram.api.types.UpdateDeleteChannelMessages`" object currently throws this exception.

It is expected to print something like the following (channel_id, message and pts redacted):
`pyrogram.api.types.UpdateDeleteChannelMessages(channel_id=1234567890, messages=pyrogram.api.core.List([1234567]), pts=1245678, pts_count=1)`

Added checks in "list.py" to see if contents of a List is not a TLObject (from the absence of a "QUALNAME" attribute). Use native `repr` function if this is the case.