### PR TITLE
Don't exclude pinned messages in get_dialogs call

### DIFF
--- a/pyrogram/client/methods/chats/get_dialogs.py
+++ b/pyrogram/client/methods/chats/get_dialogs.py
@@ -75,8 +75,7 @@ class GetDialogs(BaseClient):
                     offset_id=0,
                     offset_peer=types.InputPeerEmpty(),
                     limit=limit,
-                    hash=0,
-                    exclude_pinned=True
+                    hash=0
                 )
             )
 


### PR DESCRIPTION
Currently, when you issue a `get_dialogs` call with default parameters (precisely, 
`pinned_only=False`) — pinned messages are implicitly excluded. This PR
amends that.