### PR TITLE
Hide password on prompt

### DIFF
--- a/pyrogram/client/client.py
+++ b/pyrogram/client/client.py
@@ -24,6 +24,7 @@ import shutil
 import tempfile
 import threading
 import time
+from getpass import getpass
 from configparser import ConfigParser
 from hashlib import sha256, md5
 from importlib import import_module, reload
@@ -716,7 +717,7 @@ class Client(Methods, BaseClient):
                     print("Password hint: {}".format(self.get_password_hint()))
 
                     if not self.password:
-                        self.password = input("Enter password (empty to recover): ")
+                        self.password = getpass("Enter password (empty to recover): ")
 
                     try:
                         if not self.password:


### PR DESCRIPTION
Hiding password sudo-like using default Python module: getpass
Works on all OS(Windows, Linux, Mac)