### PR TITLE
Some fixes and speed improvments

### DIFF
--- a/compiler/api/compiler.py
+++ b/compiler/api/compiler.py
@@ -26,7 +26,7 @@ NOTICE_PATH = "NOTICE"
 SECTION_RE = re.compile(r"---(\w+)---")
 LAYER_RE = re.compile(r"//\sLAYER\s(\d+)")
 COMBINATOR_RE = re.compile(r"^([\w.]+)#([0-9a-f]+)\s(?:.*)=\s([\w<>.]+);(?: // Docs: (.+))?$", re.MULTILINE)
-ARGS_RE = re.compile("[^{](\w+):([\w?!.<>#]+)")
+ARGS_RE = re.compile(r"[^{](\w+):([\w?!.<>#]+)")
 FLAGS_RE = re.compile(r"flags\.(\d+)\?")
 FLAGS_RE_2 = re.compile(r"flags\.(\d+)\?([\w<>.]+)")
 FLAGS_RE_3 = re.compile(r"flags:#")

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 - Install requirements.
 - Install `pandoc` and `latexmk`.
-- HTML: `make html` 
+- HTML: `make html`
 - PDF: `make latexpdf`
 
 TODO: Explain better

--- a/pyrogram/client/client.py
+++ b/pyrogram/client/client.py
@@ -1649,7 +1649,7 @@ class Client(Methods, BaseClient):
         try:
             return self.storage.get_peer_by_id(peer_id)
         except KeyError:
-            if type(peer_id) is str:
+            if isinstance(peer_id, str):
                 if peer_id in ("self", "me"):
                     return types.InputPeerSelf()
 

--- a/pyrogram/client/filters/filters.py
+++ b/pyrogram/client/filters/filters.py
@@ -277,11 +277,11 @@ class Filters:
 
             return False
 
-        commands = commands if type(commands) is list else [commands]
+        commands = commands if isinstance(commands, list) else [commands]
         commands = {c if case_sensitive else c.lower() for c in commands}
 
         prefixes = [] if prefixes is None else prefixes
-        prefixes = prefixes if type(prefixes) is list else [prefixes]
+        prefixes = prefixes if isinstance(prefixes, list) else [prefixes]
         prefixes = set(prefixes) if prefixes else {""}
 
         return create(
@@ -345,11 +345,11 @@ class Filters:
         """
 
         def __init__(self, users: int or str or list = None):
-            users = [] if users is None else users if type(users) is list else [users]
+            users = [] if users is None else users if isinstance(users, list) else [users]
 
             super().__init__(
                 "me" if u in ["me", "self"]
-                else u.lower().strip("@") if type(u) is str
+                else u.lower().strip("@") if isinstance(u, str)
                 else u for u in users
             )
 
@@ -376,11 +376,11 @@ class Filters:
         """
 
         def __init__(self, chats: int or str or list = None):
-            chats = [] if chats is None else chats if type(chats) is list else [chats]
+            chats = [] if chats is None else chats if isinstance(chats, list) else [chats]
 
             super().__init__(
                 "me" if c in ["me", "self"]
-                else c.lower().strip("@") if type(c) is str
+                else c.lower().strip("@") if isinstance(c, str)
                 else c for c in chats
             )
 

--- a/pyrogram/client/filters/filters.py
+++ b/pyrogram/client/filters/filters.py
@@ -214,7 +214,7 @@ class Filters:
 
     from_scheduled = create(lambda _, m: bool(m.from_scheduled), "FromScheduledFilter")
     """Filter new automatically sent messages that were previously scheduled."""
-    
+
     # Messages from linked channels are forwarded automatically by Telegram and have no sender (from_user is None).
     linked_channel = create(lambda _, m: bool(m.forward_from_chat and not m.from_user), "LinkedChannelFilter")
     """Filter messages that are automatically forwarded from the linked channel to the group chat."""

--- a/pyrogram/client/methods/chats/delete_user_history.py
+++ b/pyrogram/client/methods/chats/delete_user_history.py
@@ -18,7 +18,7 @@
 
 from typing import Union
 
-from pyrogram.api import functions, types
+from pyrogram.api import functions
 from pyrogram.client.ext import BaseClient
 
 

--- a/pyrogram/client/methods/chats/get_chat_members.py
+++ b/pyrogram/client/methods/chats/get_chat_members.py
@@ -17,12 +17,10 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-import time
 from typing import Union, List
 
 import pyrogram
 from pyrogram.api import functions, types
-from pyrogram.errors import FloodWait
 from ...ext import BaseClient
 
 log = logging.getLogger(__name__)

--- a/pyrogram/client/methods/chats/get_dialogs.py
+++ b/pyrogram/client/methods/chats/get_dialogs.py
@@ -17,12 +17,10 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-import time
 from typing import List
 
 import pyrogram
 from pyrogram.api import functions, types
-from pyrogram.errors import FloodWait
 from ...ext import BaseClient, utils
 
 log = logging.getLogger(__name__)

--- a/pyrogram/client/methods/chats/set_chat_photo.py
+++ b/pyrogram/client/methods/chats/set_chat_photo.py
@@ -41,7 +41,7 @@ class SetChatPhoto(BaseClient):
             photo (``str``):
                 New chat photo. You can pass a :obj:`Photo` file_id or a file path to upload a new photo from your local
                 machine.
-                
+
             file_ref (``str``, *optional*):
                 A valid file reference obtained by a recently fetched media message.
                 To be used in combination with a file id in case a file reference is needed.

--- a/pyrogram/client/methods/chats/update_chat_username.py
+++ b/pyrogram/client/methods/chats/update_chat_username.py
@@ -29,7 +29,7 @@ class UpdateChatUsername(BaseClient):
         username: Union[str, None]
     ) -> bool:
         """Update a channel or a supergroup username.
-        
+
         To update your own username (for users only, not bots) you can use :meth:`~Client.update_username`.
 
         Parameters:

--- a/pyrogram/client/methods/messages/get_history.py
+++ b/pyrogram/client/methods/messages/get_history.py
@@ -17,13 +17,11 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-import time
 from typing import Union, List
 
 import pyrogram
 from pyrogram.api import functions
 from pyrogram.client.ext import utils
-from pyrogram.errors import FloodWait
 from ...ext import BaseClient
 
 log = logging.getLogger(__name__)

--- a/pyrogram/client/methods/messages/get_messages.py
+++ b/pyrogram/client/methods/messages/get_messages.py
@@ -17,12 +17,10 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-import time
 from typing import Union, Iterable, List
 
 import pyrogram
 from pyrogram.api import functions, types
-from pyrogram.errors import FloodWait
 from ...ext import BaseClient, utils
 
 log = logging.getLogger(__name__)

--- a/pyrogram/client/methods/users/get_common_chats.py
+++ b/pyrogram/client/methods/users/get_common_chats.py
@@ -35,7 +35,7 @@ class GetCommonChats(BaseClient):
 
         Returns:
             List of :obj:`Chat`: On success, a list of the common chats is returned.
-            
+
         Raises:
             ValueError: If the user_id doesn't belong to a user.
 
@@ -58,5 +58,5 @@ class GetCommonChats(BaseClient):
             )
 
             return pyrogram.List([pyrogram.Chat._parse_chat(self, x) for x in r.chats])
-        
+
         raise ValueError('The user_id "{}" doesn\'t belong to a user'.format(user_id))

--- a/pyrogram/client/methods/users/update_profile.py
+++ b/pyrogram/client/methods/users/update_profile.py
@@ -28,13 +28,13 @@ class UpdateProfile(BaseClient):
         bio: str = None
     ) -> bool:
         """Update your profile details such as first name, last name and bio.
-        
+
         You can omit the parameters you don't want to change.
-        
+
         Parameters:
             first_name (``str``, *optional*):
                 The new first name.
-        
+
             last_name (``str``, *optional*):
                 The new last name.
                 Pass "" (empty string) to remove it.
@@ -42,19 +42,19 @@ class UpdateProfile(BaseClient):
             bio (``str``, *optional*):
                 The new bio, also known as "about". Max 70 characters.
                 Pass "" (empty string) to remove it.
-                
+
         Returns:
             ``bool``: True on success.
-        
+
         Example:
             .. code-block:: python
-                
+
                 # Update your first name only
                 app.update_profile(first_name="Pyrogram")
-                
+
                 # Update first name and bio
                 app.update_profile(first_name="Pyrogram", bio="https://docs.pyrogram.org/")
-                
+
                 # Remove the last name
                 app.update_profile(last_name="")
         """

--- a/pyrogram/client/methods/users/update_username.py
+++ b/pyrogram/client/methods/users/update_username.py
@@ -28,7 +28,7 @@ class UpdateUsername(BaseClient):
         username: Union[str, None]
     ) -> bool:
         """Update your own username.
-        
+
         This method only works for users, not bots. Bot usernames must be changed via Bot Support or by recreating
         them from scratch using BotFather. To update a channel or supergroup username you can use
         :meth:`~Client.update_chat_username`.

--- a/pyrogram/client/types/inline_mode/chosen_inline_result.py
+++ b/pyrogram/client/types/inline_mode/chosen_inline_result.py
@@ -33,7 +33,6 @@
 
 from base64 import b64encode
 from struct import pack
-from typing import Union
 
 import pyrogram
 from pyrogram.api import types
@@ -41,7 +40,6 @@ from pyrogram.client.types.object import Object
 from pyrogram.client.types.update import Update
 from pyrogram.client.types.user_and_chats import User
 from pyrogram.client.types.messages_and_media import Location
-from pyrogram.client.ext import utils
 
 
 class ChosenInlineResult(Object, Update):

--- a/pyrogram/client/types/messages_and_media/dice.py
+++ b/pyrogram/client/types/messages_and_media/dice.py
@@ -16,14 +16,9 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from struct import pack
-from typing import List
-
 import pyrogram
 from pyrogram.api import types
-from .thumbnail import Thumbnail
 from ..object import Object
-from ...ext.utils import encode_file_id, encode_file_ref
 
 
 class Dice(Object):

--- a/pyrogram/client/types/messages_and_media/message.py
+++ b/pyrogram/client/types/messages_and_media/message.py
@@ -2964,7 +2964,7 @@ class Message(Object, Update):
                 chat_id=message.chat.id,
                 message_id=message_id,
             )
-            
+
         Example:
             .. code-block:: python
 
@@ -3074,7 +3074,7 @@ class Message(Object, Update):
         Parameters:
             option (``int``):
                 Index of the poll option you want to vote for (0 to 9).
-            
+
         Returns:
             :obj:`Poll`: On success, the poll with the chosen option is returned.
 

--- a/pyrogram/session/internals/msg_factory.py
+++ b/pyrogram/session/internals/msg_factory.py
@@ -23,7 +23,7 @@ from pyrogram.api.core import Message, MsgContainer, TLObject
 from .msg_id import MsgId
 from .seq_no import SeqNo
 
-not_content_related = [Ping, HttpWait, MsgsAck, MsgContainer]
+not_content_related = (Ping, HttpWait, MsgsAck, MsgContainer)
 
 
 class MsgFactory:
@@ -34,6 +34,6 @@ class MsgFactory:
         return Message(
             body,
             MsgId(),
-            self.seq_no(type(body) not in not_content_related),
+            self.seq_no(not isinstance(body, not_content_related)),
             len(body)
         )


### PR DESCRIPTION
## Changes
- Use raw string in `compiler/api/compiler.py` re pattern.
- Trim trailing whitespaces from docstrings and code.
- Use `isinstance()` instead of `type()` for typechecking (isinstance is faster and the default way for typechecking).
- Cleaned up unused imports, mostly due to old code that was removed (Imports declared in docstrings were kept, though).