### PR TITLE
fix for new format

### DIFF
--- a/pyrogram/client/methods/chats/get_nearby_chats.py
+++ b/pyrogram/client/methods/chats/get_nearby_chats.py
@@ -64,7 +64,7 @@ class GetNearbyChats(BaseClient):
         peers = r.updates[0].peers
 
         for peer in peers:
-            if type(peer.peer) is types.PeerChannel:
+            if isinstance(peer.peer, types.PeerChannel):
                 chat_id = utils.get_channel_id(peer.peer.channel_id)
 
                 for chat in chats:

--- a/pyrogram/client/methods/chats/get_nearby_chats.py
+++ b/pyrogram/client/methods/chats/get_nearby_chats.py
@@ -64,11 +64,12 @@ class GetNearbyChats(BaseClient):
         peers = r.updates[0].peers
 
         for peer in peers:
-            chat_id = utils.get_channel_id(peer.peer.channel_id)
+            if type(peer.peer) is types.PeerChannel:
+                chat_id = utils.get_channel_id(peer.peer.channel_id)
 
-            for chat in chats:
-                if chat.id == chat_id:
-                    chat.distance = peer.distance
-                    break
+                for chat in chats:
+                    if chat.id == chat_id:
+                        chat.distance = peer.distance
+                        break
 
         return chats


### PR DESCRIPTION
This fixes the `AttributeError: 'PeerUser' object has no attribute 'channel_id'`. Telegram must've changed the format.
Maybe we should also have a method to show nearby users?