### PR TITLE
Fix inline message edit issue and inline result caption

### DIFF
--- a/pyrogram/client/methods/messages/edit_inline_text.py
+++ b/pyrogram/client/methods/messages/edit_inline_text.py
@@ -20,6 +20,8 @@ from typing import Union
 
 import pyrogram
 from pyrogram.api import functions
+from pyrogram.session import Auth, Session
+from pyrogram.errors import AuthBytesInvalid
 from pyrogram.client.ext import BaseClient, utils
 
 
@@ -71,11 +73,51 @@ class EditInlineText(BaseClient):
                     disable_web_page_preview=True)
         """
 
-        return await self.send(
-            functions.messages.EditInlineBotMessage(
-                id=utils.unpack_inline_message_id(inline_message_id),
-                no_webpage=disable_web_page_preview or None,
-                reply_markup=reply_markup.write() if reply_markup else None,
-                **await self.parser.parse(text, parse_mode)
+        unpacked = utils.unpack_inline_message_id(inline_message_id)
+
+        if unpacked.dc_id != self.storage.dc_id():
+            session = Session(self, unpacked.dc_id, await Auth(self, unpacked.dc_id).create(), is_media=True)
+
+            await session.start()
+
+            for _ in range(3):
+                exported_auth = await self.send(
+                    functions.auth.ExportAuthorization(
+                        dc_id=unpacked.dc_id
+                    )
+                )
+
+                try:
+                    await session.send(
+                        functions.auth.ImportAuthorization(
+                            id=exported_auth.id,
+                            bytes=exported_auth.bytes
+                        )
+                    )
+                except AuthBytesInvalid:
+                    continue
+                else:
+                    break
+            else:
+                await session.stop()
+                raise AuthBytesInvalid
+
+            await session.send(
+                functions.messages.EditInlineBotMessage(
+                    id=unpacked,
+                    no_webpage=disable_web_page_preview or None,
+                    reply_markup=reply_markup.write() if reply_markup else None,
+                    **await self.parser.parse(text, parse_mode)
+                )
             )
-        )
+
+            await session.stop()
+        else:
+            await self.send(
+                functions.messages.EditInlineBotMessage(
+                    id=unpacked,
+                    no_webpage=disable_web_page_preview or None,
+                    reply_markup=reply_markup.write() if reply_markup else None,
+                    **await self.parser.parse(text, parse_mode)
+                )
+            )

--- a/pyrogram/client/types/inline_mode/inline_query_result_animation.py
+++ b/pyrogram/client/types/inline_mode/inline_query_result_animation.py
@@ -75,7 +75,7 @@ class InlineQueryResultAnimation(InlineQueryResult):
         id: str = None,
         title: str = None,
         description: str = None,
-        caption: str = None,
+        caption: str = '',
         parse_mode: Union[str, None] = object,
         reply_markup: InlineKeyboardMarkup = None,
         input_message_content: InputMessageContent = None

--- a/pyrogram/client/types/inline_mode/inline_query_result_photo.py
+++ b/pyrogram/client/types/inline_mode/inline_query_result_photo.py
@@ -75,7 +75,7 @@ class InlineQueryResultPhoto(InlineQueryResult):
         id: str = None,
         title: str = None,
         description: str = None,
-        caption: str = None,
+        caption: str = '',
         parse_mode: Union[str, None] = object,
         reply_markup: InlineKeyboardMarkup = None,
         input_message_content: InputMessageContent = None


### PR DESCRIPTION
Fix inline edit media, text and reply markup for different dc peers which was patched in test branch and fix for None showing in inline result captions by default (when not provided).