### PR TITLE
Update save_file function to support pathlib objects

### DIFF
--- a/pyrogram/client/client.py
+++ b/pyrogram/client/client.py
@@ -28,7 +28,7 @@ import time
 from configparser import ConfigParser
 from hashlib import sha256, md5
 from importlib import import_module
-from pathlib import Path
+from pathlib import Path, PurePath
 from signal import signal, SIGINT, SIGTERM, SIGABRT
 from threading import Thread
 from typing import Union, List, BinaryIO
@@ -1788,7 +1788,7 @@ class Client(Methods, BaseClient):
 
         part_size = 512 * 1024
 
-        if isinstance(path, str):
+        if isinstance(path, str) or isinstance(path, PurePath):
             fp = open(path, "rb")
         elif isinstance(path, io.IOBase):
             fp = path


### PR DESCRIPTION
save_file can now support pathlib objects.

As open() also supports pathlib object already, combining the same if statement for string paths and pathlib objects works perfectly fine