### PR TITLE
Allow dialog methods to fetch archived chats

### DIFF
--- a/pyrogram/methods/chats/get_dialogs.py
+++ b/pyrogram/methods/chats/get_dialogs.py
@@ -32,7 +32,8 @@ class GetDialogs(Scaffold):
         self,
         offset_date: int = 0,
         limit: int = 100,
-        pinned_only: bool = False
+        pinned_only: bool = False,
+        archived_only: bool = False
     ) -> List["types.Dialog"]:
         """Get a chunk of the user's dialogs.
 
@@ -52,6 +53,10 @@ class GetDialogs(Scaffold):
                 Pass True if you want to get only pinned dialogs.
                 Defaults to False.
 
+            archived_only (``bool``, *optional*):
+                Pass True if you want to get only archived dialogs.
+                Defaults to False.
+
         Returns:
             List of :obj:`~pyrogram.types.Dialog`: On success, a list of dialogs is returned.
 
@@ -63,11 +68,14 @@ class GetDialogs(Scaffold):
 
                 # Get pinned dialogs
                 app.get_dialogs(pinned_only=True)
+
+                # Get archived dialogs
+                app.get_dialogs(archived_only=True)
         """
 
         if pinned_only:
             r = await self.send(
-                raw.functions.messages.GetPinnedDialogs(folder_id=0),
+                raw.functions.messages.GetPinnedDialogs(folder_id=archived_only),
                 sleep_threshold=60
             )
         else:
@@ -78,7 +86,8 @@ class GetDialogs(Scaffold):
                     offset_peer=raw.types.InputPeerEmpty(),
                     limit=limit,
                     hash=0,
-                    exclude_pinned=True
+                    exclude_pinned=True,
+                    folder_id=archived_only
                 ),
                 sleep_threshold=60
             )

--- a/pyrogram/methods/chats/get_dialogs_count.py
+++ b/pyrogram/methods/chats/get_dialogs_count.py
@@ -21,12 +21,21 @@ from pyrogram.scaffold import Scaffold
 
 
 class GetDialogsCount(Scaffold):
-    async def get_dialogs_count(self, pinned_only: bool = False) -> int:
+    async def get_dialogs_count(
+        self,
+        pinned_only: bool = False,
+        archived_only: bool = False
+    ) -> int:
         """Get the total count of your dialogs.
 
-        pinned_only (``bool``, *optional*):
-            Pass True if you want to count only pinned dialogs.
-            Defaults to False.
+        Parameters:
+            pinned_only (``bool``, *optional*):
+                Pass True if you want to count only pinned dialogs.
+                Defaults to False.
+
+            archived_only (``bool``, *optional*):
+                Pass True if you want to count only archived dialogs.
+                Defaults to False.
 
         Returns:
             ``int``: On success, the dialogs count is returned.
@@ -39,7 +48,7 @@ class GetDialogsCount(Scaffold):
         """
 
         if pinned_only:
-            return len((await self.send(raw.functions.messages.GetPinnedDialogs(folder_id=0))).dialogs)
+            return len((await self.send(raw.functions.messages.GetPinnedDialogs(folder_id=archived_only))).dialogs)
         else:
             r = await self.send(
                 raw.functions.messages.GetDialogs(
@@ -47,7 +56,8 @@ class GetDialogsCount(Scaffold):
                     offset_id=0,
                     offset_peer=raw.types.InputPeerEmpty(),
                     limit=1,
-                    hash=0
+                    hash=0,
+                    folder_id=archived_only
                 )
             )
 

--- a/pyrogram/methods/chats/iter_dialogs.py
+++ b/pyrogram/methods/chats/iter_dialogs.py
@@ -26,7 +26,8 @@ class IterDialogs(Scaffold):
     async def iter_dialogs(
         self,
         limit: int = 0,
-        offset_date: int = 0
+        offset_date: int = 0,
+        archived_only: bool = False
     ) -> Optional[AsyncGenerator["types.Dialog", None]]:
         """Iterate through a user's dialogs sequentially.
 
@@ -43,6 +44,10 @@ class IterDialogs(Scaffold):
                 The offset date in Unix time taken from the top message of a :obj:`~pyrogram.types.Dialog`.
                 Defaults to 0 (most recent dialog).
 
+            archived_only (``bool``, *optional*):
+                Pass True if you want to get only archived dialogs.
+                Defaults to False.
+
         Returns:
             ``Generator``: A generator yielding :obj:`~pyrogram.types.Dialog` objects.
 
@@ -58,7 +63,7 @@ class IterDialogs(Scaffold):
         limit = min(100, total)
 
         pinned_dialogs = await self.get_dialogs(
-            pinned_only=True
+            pinned_only=True, archived_only=archived_only
         )
 
         for dialog in pinned_dialogs:
@@ -72,7 +77,8 @@ class IterDialogs(Scaffold):
         while True:
             dialogs = await self.get_dialogs(
                 offset_date=offset_date,
-                limit=limit
+                limit=limit,
+                archived_only=archived_only
             )
 
             if not dialogs:

--- a/pyrogram/types/user_and_chats/dialog.py
+++ b/pyrogram/types/user_and_chats/dialog.py
@@ -44,6 +44,9 @@ class Dialog(Object):
 
         is_pinned (``bool``):
             True, if the dialog is pinned.
+
+        is_archived (``bool``):
+            True, if the dialog is archived.
     """
 
     def __init__(
@@ -55,7 +58,8 @@ class Dialog(Object):
         unread_messages_count: int,
         unread_mentions_count: int,
         unread_mark: bool,
-        is_pinned: bool
+        is_pinned: bool,
+        is_archived: bool
     ):
         super().__init__(client)
 
@@ -65,6 +69,7 @@ class Dialog(Object):
         self.unread_mentions_count = unread_mentions_count
         self.unread_mark = unread_mark
         self.is_pinned = is_pinned
+        self.is_archived = is_archived
 
     @staticmethod
     def _parse(client, dialog: "raw.types.Dialog", messages, users, chats) -> "Dialog":
@@ -75,5 +80,6 @@ class Dialog(Object):
             unread_mentions_count=dialog.unread_mentions_count,
             unread_mark=dialog.unread_mark,
             is_pinned=dialog.pinned,
+            is_archived=bool(dialog.folder_id),
             client=client
         )


### PR DESCRIPTION
This PR closes #362 

get_dialogs_count/get_dialogs/iter_dialogs: Added "archived_only" kwarg.

types.Dialog: Added "is_archived" boolean attribute.