### PR TITLE
Made pyrogram objects pickable

### DIFF
--- a/pyrogram/types/object.py
+++ b/pyrogram/types/object.py
@@ -95,3 +95,8 @@ class Object(metaclass=Meta):
 
     def __setitem__(self, key, value):
         setattr(self, key, value)
+
+    def __getstate__(self):
+        new_dict = self.__dict__.copy()
+        new_dict.pop("_client", None)
+        return new_dict


### PR DESCRIPTION
Title is self explanatory.
Added `__getstate__` to ignore `Object._client` while pickle is doing its job. ([What does __getstate__ do?](https://docs.python.org/3/library/pickle.html#object.__getstate__))