### PR TITLE
Improve typing hints

### DIFF
--- a/pyrogram/client.py
+++ b/pyrogram/client.py
@@ -29,7 +29,7 @@ from configparser import ConfigParser
 from hashlib import sha256
 from importlib import import_module
 from pathlib import Path
-from typing import Union, List
+from typing import Union, List, Optional
 
 import pyrogram
 from pyrogram import raw
@@ -396,7 +396,7 @@ class Client(Methods, Scaffold):
         return self._parse_mode
 
     @parse_mode.setter
-    def parse_mode(self, parse_mode: Union[str, None] = "combined"):
+    def parse_mode(self, parse_mode: Optional[str] = "combined"):
         if parse_mode not in self.PARSE_MODES:
             raise ValueError('parse_mode must be one of {} or None. Not "{}"'.format(
                 ", ".join(f'"{m}"' for m in self.PARSE_MODES[:-1]),
@@ -406,7 +406,7 @@ class Client(Methods, Scaffold):
         self._parse_mode = parse_mode
 
     # TODO: redundant, remove in next major version
-    def set_parse_mode(self, parse_mode: Union[str, None] = "combined"):
+    def set_parse_mode(self, parse_mode: Optional[str] = "combined"):
         """Set the parse mode to be used globally by the client.
 
         When setting the parse mode with this method, all other methods having a *parse_mode* parameter will follow the

--- a/pyrogram/connection/connection.py
+++ b/pyrogram/connection/connection.py
@@ -19,6 +19,8 @@
 import asyncio
 import logging
 
+from typing import Union
+
 from .transport import *
 from ..session.internals import DataCenter
 
@@ -79,5 +81,5 @@ class Connection:
         except Exception:
             raise OSError
 
-    async def recv(self) -> bytes or None:
+    async def recv(self) -> Union[bytes, None]:
         return await self.protocol.recv()

--- a/pyrogram/connection/connection.py
+++ b/pyrogram/connection/connection.py
@@ -19,7 +19,7 @@
 import asyncio
 import logging
 
-from typing import Union
+from typing import Optional
 
 from .transport import *
 from ..session.internals import DataCenter
@@ -81,5 +81,5 @@ class Connection:
         except Exception:
             raise OSError
 
-    async def recv(self) -> Union[bytes, None]:
+    async def recv(self) -> Optional[bytes]:
         return await self.protocol.recv()

--- a/pyrogram/connection/transport/tcp/tcp_abridged.py
+++ b/pyrogram/connection/transport/tcp/tcp_abridged.py
@@ -18,7 +18,7 @@
 
 import logging
 
-from typing import Union
+from typing import Optional
 
 from .tcp import TCP
 
@@ -43,7 +43,7 @@ class TCPAbridged(TCP):
             + data
         )
 
-    async def recv(self, length: int = 0) -> Union[bytes, None]:
+    async def recv(self, length: int = 0) -> Optional[bytes]:
         length = await super().recv(1)
 
         if length is None:

--- a/pyrogram/connection/transport/tcp/tcp_abridged.py
+++ b/pyrogram/connection/transport/tcp/tcp_abridged.py
@@ -18,6 +18,8 @@
 
 import logging
 
+from typing import Union
+
 from .tcp import TCP
 
 log = logging.getLogger(__name__)
@@ -41,7 +43,7 @@ class TCPAbridged(TCP):
             + data
         )
 
-    async def recv(self, length: int = 0) -> bytes or None:
+    async def recv(self, length: int = 0) -> Union[bytes, None]:
         length = await super().recv(1)
 
         if length is None:

--- a/pyrogram/connection/transport/tcp/tcp_abridged_o.py
+++ b/pyrogram/connection/transport/tcp/tcp_abridged_o.py
@@ -19,7 +19,10 @@
 import logging
 import os
 
+from typing import Union
+
 from pyrogram import utils
+
 from pyrogram.crypto import aes
 from .tcp import TCP
 
@@ -61,7 +64,7 @@ class TCPAbridgedO(TCP):
 
         await super().send(payload)
 
-    async def recv(self, length: int = 0) -> bytes or None:
+    async def recv(self, length: int = 0) -> Union[bytes, None]:
         length = await super().recv(1)
 
         if length is None:

--- a/pyrogram/connection/transport/tcp/tcp_abridged_o.py
+++ b/pyrogram/connection/transport/tcp/tcp_abridged_o.py
@@ -19,7 +19,7 @@
 import logging
 import os
 
-from typing import Union
+from typing import Optional
 
 from pyrogram import utils
 
@@ -64,7 +64,7 @@ class TCPAbridgedO(TCP):
 
         await super().send(payload)
 
-    async def recv(self, length: int = 0) -> Union[bytes, None]:
+    async def recv(self, length: int = 0) -> Optional[bytes]:
         length = await super().recv(1)
 
         if length is None:

--- a/pyrogram/connection/transport/tcp/tcp_full.py
+++ b/pyrogram/connection/transport/tcp/tcp_full.py
@@ -17,6 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
+from typing import Union
 from binascii import crc32
 from struct import pack, unpack
 
@@ -42,7 +43,7 @@ class TCPFull(TCP):
 
         await super().send(data)
 
-    async def recv(self, length: int = 0) -> bytes or None:
+    async def recv(self, length: int = 0) -> Union[bytes, None]:
         length = await super().recv(4)
 
         if length is None:

--- a/pyrogram/connection/transport/tcp/tcp_full.py
+++ b/pyrogram/connection/transport/tcp/tcp_full.py
@@ -17,7 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-from typing import Union
+from typing import Optional
 from binascii import crc32
 from struct import pack, unpack
 
@@ -43,7 +43,7 @@ class TCPFull(TCP):
 
         await super().send(data)
 
-    async def recv(self, length: int = 0) -> Union[bytes, None]:
+    async def recv(self, length: int = 0) -> Optional[bytes]:
         length = await super().recv(4)
 
         if length is None:

--- a/pyrogram/connection/transport/tcp/tcp_intermediate.py
+++ b/pyrogram/connection/transport/tcp/tcp_intermediate.py
@@ -17,7 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-from typing import Union
+from typing import Optional
 from struct import pack, unpack
 
 from .tcp import TCP
@@ -36,7 +36,7 @@ class TCPIntermediate(TCP):
     async def send(self, data: bytes, *args):
         await super().send(pack("<i", len(data)) + data)
 
-    async def recv(self, length: int = 0) -> Union[bytes, None]:
+    async def recv(self, length: int = 0) -> Optional[bytes]:
         length = await super().recv(4)
 
         if length is None:

--- a/pyrogram/connection/transport/tcp/tcp_intermediate.py
+++ b/pyrogram/connection/transport/tcp/tcp_intermediate.py
@@ -17,6 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
+from typing import Union
 from struct import pack, unpack
 
 from .tcp import TCP
@@ -35,7 +36,7 @@ class TCPIntermediate(TCP):
     async def send(self, data: bytes, *args):
         await super().send(pack("<i", len(data)) + data)
 
-    async def recv(self, length: int = 0) -> bytes or None:
+    async def recv(self, length: int = 0) -> Union[bytes, None]:
         length = await super().recv(4)
 
         if length is None:

--- a/pyrogram/connection/transport/tcp/tcp_intermediate_o.py
+++ b/pyrogram/connection/transport/tcp/tcp_intermediate_o.py
@@ -18,7 +18,7 @@
 
 import logging
 import os
-from typing import Union
+from typing import Optional
 from struct import pack, unpack
 
 from pyrogram.crypto import aes
@@ -63,7 +63,7 @@ class TCPIntermediateO(TCP):
             )
         )
 
-    async def recv(self, length: int = 0) -> Union[bytes, None]:
+    async def recv(self, length: int = 0) -> Optional[bytes]:
         length = await super().recv(4)
 
         if length is None:

--- a/pyrogram/connection/transport/tcp/tcp_intermediate_o.py
+++ b/pyrogram/connection/transport/tcp/tcp_intermediate_o.py
@@ -18,6 +18,7 @@
 
 import logging
 import os
+from typing import Union
 from struct import pack, unpack
 
 from pyrogram.crypto import aes
@@ -62,7 +63,7 @@ class TCPIntermediateO(TCP):
             )
         )
 
-    async def recv(self, length: int = 0) -> bytes or None:
+    async def recv(self, length: int = 0) -> Union[bytes, None]:
         length = await super().recv(4)
 
         if length is None:

--- a/pyrogram/errors/rpc_error.py
+++ b/pyrogram/errors/rpc_error.py
@@ -19,7 +19,7 @@
 import re
 from datetime import datetime
 from importlib import import_module
-from typing import Type
+from typing import Type, Union
 
 from pyrogram import raw
 from pyrogram.raw.core import TLObject
@@ -32,7 +32,7 @@ class RPCError(Exception):
     NAME = None
     MESSAGE = "{x}"
 
-    def __init__(self, x: int or raw.types.RpcError = None, rpc_name: str = None, is_unknown: bool = False):
+    def __init__(self, x: Union[int, raw.types.RpcError] = None, rpc_name: str = None, is_unknown: bool = False):
         super().__init__("[{} {}]: {} {}".format(
             self.CODE,
             self.ID or self.NAME,

--- a/pyrogram/filters.py
+++ b/pyrogram/filters.py
@@ -824,7 +824,7 @@ class user(Filter, set):
             Defaults to None (no users).
     """
 
-    def __init__(self, users: Union[int, str, list] = None):
+    def __init__(self, users: Union[int, str, List[Union[int, str]]] = None):
         users = [] if users is None else users if isinstance(users, list) else [users]
 
         super().__init__(
@@ -856,7 +856,7 @@ class chat(Filter, set):
             Defaults to None (no chats).
     """
 
-    def __init__(self, chats: Union[int, str, list] = None):
+    def __init__(self, chats: Union[int, str, List[Union[int, str]]] = None):
         chats = [] if chats is None else chats if isinstance(chats, list) else [chats]
 
         super().__init__(

--- a/pyrogram/filters.py
+++ b/pyrogram/filters.py
@@ -699,7 +699,7 @@ linked_channel = create(linked_channel_filter)
 # endregion
 
 
-def command(commands: str or List[str], prefixes: str or List[str] = "/", case_sensitive: bool = False):
+def command(commands: Union[str, List[str]], prefixes: Union[str, List[str]] = "/", case_sensitive: bool = False):
     """Filter commands, i.e.: text messages starting with "/" or any other custom prefix.
 
     Parameters:
@@ -824,7 +824,7 @@ class user(Filter, set):
             Defaults to None (no users).
     """
 
-    def __init__(self, users: int or str or list = None):
+    def __init__(self, users: Union[int, str, list] = None):
         users = [] if users is None else users if isinstance(users, list) else [users]
 
         super().__init__(
@@ -856,7 +856,7 @@ class chat(Filter, set):
             Defaults to None (no chats).
     """
 
-    def __init__(self, chats: int or str or list = None):
+    def __init__(self, chats: Union[int, str, list] = None):
         chats = [] if chats is None else chats if isinstance(chats, list) else [chats]
 
         super().__init__(

--- a/pyrogram/methods/chats/set_slow_mode.py
+++ b/pyrogram/methods/chats/set_slow_mode.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from typing import Union, Optional
 
 from pyrogram import raw
 from pyrogram.scaffold import Scaffold
@@ -26,7 +26,7 @@ class SetSlowMode(Scaffold):
     async def set_slow_mode(
         self,
         chat_id: Union[int, str],
-        seconds: Union[int, None]
+        seconds: Optional[int]
     ) -> bool:
         """Set the slow mode interval for a chat.
 

--- a/pyrogram/methods/chats/update_chat_username.py
+++ b/pyrogram/methods/chats/update_chat_username.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from typing import Union, Optional
 
 from pyrogram import raw
 from pyrogram.scaffold import Scaffold
@@ -26,7 +26,7 @@ class UpdateChatUsername(Scaffold):
     async def update_chat_username(
         self,
         chat_id: Union[int, str],
-        username: Union[str, None]
+        username: Optional[str]
     ) -> bool:
         """Update a channel or a supergroup username.
 

--- a/pyrogram/methods/messages/copy_message.py
+++ b/pyrogram/methods/messages/copy_message.py
@@ -17,7 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-from typing import Union, List
+from typing import Union, List, Optional
 
 from pyrogram import types
 from pyrogram.scaffold import Scaffold
@@ -32,7 +32,7 @@ class CopyMessage(Scaffold):
         from_chat_id: Union[int, str],
         message_id: int,
         caption: str = None,
-        parse_mode: Union[str, None] = object,
+        parse_mode: Optional[str] = object,
         caption_entities: List["types.MessageEntity"] = None,
         disable_notification: bool = None,
         reply_to_message_id: int = None,

--- a/pyrogram/methods/messages/download_media.py
+++ b/pyrogram/methods/messages/download_media.py
@@ -20,7 +20,7 @@ import asyncio
 import os
 import time
 from datetime import datetime
-from typing import Union
+from typing import Union, Optional
 
 from pyrogram import types
 from pyrogram.file_id import FileId, FileType, PHOTO_TYPES
@@ -37,7 +37,7 @@ class DownloadMedia(Scaffold):
         block: bool = True,
         progress: callable = None,
         progress_args: tuple = ()
-    ) -> Union[str, None]:
+    ) -> Optional[str]:
         """Download the media from a message.
 
         Parameters:

--- a/pyrogram/methods/messages/edit_inline_caption.py
+++ b/pyrogram/methods/messages/edit_inline_caption.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from typing import Optional
 
 from pyrogram import types
 from pyrogram.scaffold import Scaffold
@@ -27,7 +27,7 @@ class EditInlineCaption(Scaffold):
         self,
         inline_message_id: str,
         caption: str,
-        parse_mode: Union[str, None] = object,
+        parse_mode: Optional[str] = object,
         reply_markup: "types.InlineKeyboardMarkup" = None
     ) -> bool:
         """Edit the caption of inline media messages.

--- a/pyrogram/methods/messages/edit_inline_text.py
+++ b/pyrogram/methods/messages/edit_inline_text.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from typing import Optional
 
 from pyrogram import raw
 from pyrogram import types
@@ -30,7 +30,7 @@ class EditInlineText(Scaffold):
         self,
         inline_message_id: str,
         text: str,
-        parse_mode: Union[str, None] = object,
+        parse_mode: Optional[str] = object,
         disable_web_page_preview: bool = None,
         reply_markup: "types.InlineKeyboardMarkup" = None
     ) -> bool:

--- a/pyrogram/methods/messages/edit_message_caption.py
+++ b/pyrogram/methods/messages/edit_message_caption.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union, List
+from typing import Union, List, Optional
 
 from pyrogram import types
 from pyrogram.scaffold import Scaffold
@@ -28,7 +28,7 @@ class EditMessageCaption(Scaffold):
         chat_id: Union[int, str],
         message_id: int,
         caption: str,
-        parse_mode: Union[str, None] = object,
+        parse_mode: Optional[str] = object,
         caption_entities: List["types.MessageEntity"] = None,
         reply_markup: "types.InlineKeyboardMarkup" = None
     ) -> "types.Message":

--- a/pyrogram/methods/messages/edit_message_text.py
+++ b/pyrogram/methods/messages/edit_message_text.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union, List
+from typing import Union, List, Optional
 
 from pyrogram import raw
 from pyrogram import types
@@ -30,7 +30,7 @@ class EditMessageText(Scaffold):
         chat_id: Union[int, str],
         message_id: int,
         text: str,
-        parse_mode: Union[str, None] = object,
+        parse_mode: Optional[str] = object,
         entities: List["types.MessageEntity"] = None,
         disable_web_page_preview: bool = None,
         reply_markup: "types.InlineKeyboardMarkup" = None

--- a/pyrogram/methods/messages/send_animation.py
+++ b/pyrogram/methods/messages/send_animation.py
@@ -18,7 +18,7 @@
 
 import os
 import re
-from typing import Union, BinaryIO, List
+from typing import Union, BinaryIO, List, Optional
 
 from pyrogram import StopTransmission
 from pyrogram import raw
@@ -36,7 +36,7 @@ class SendAnimation(Scaffold):
         animation: Union[str, BinaryIO],
         caption: str = "",
         unsave: bool = False,
-        parse_mode: Union[str, None] = object,
+        parse_mode: Optional[str] = object,
         caption_entities: List["types.MessageEntity"] = None,
         duration: int = 0,
         width: int = 0,
@@ -54,7 +54,7 @@ class SendAnimation(Scaffold):
         ] = None,
         progress: callable = None,
         progress_args: tuple = ()
-    ) -> Union["types.Message", None]:
+    ) -> Optional["types.Message"]:
         """Send animation files (animation or H.264/MPEG-4 AVC video without sound).
 
         Parameters:

--- a/pyrogram/methods/messages/send_audio.py
+++ b/pyrogram/methods/messages/send_audio.py
@@ -18,7 +18,7 @@
 
 import os
 import re
-from typing import Union, BinaryIO, List
+from typing import Union, BinaryIO, List, Optional
 
 from pyrogram import StopTransmission
 from pyrogram import raw
@@ -35,7 +35,7 @@ class SendAudio(Scaffold):
         chat_id: Union[int, str],
         audio: Union[str, BinaryIO],
         caption: str = "",
-        parse_mode: Union[str, None] = object,
+        parse_mode: Optional[str] = object,
         caption_entities: List["types.MessageEntity"] = None,
         duration: int = 0,
         performer: str = None,
@@ -53,7 +53,7 @@ class SendAudio(Scaffold):
         ] = None,
         progress: callable = None,
         progress_args: tuple = ()
-    ) -> Union["types.Message", None]:
+    ) -> Optional["types.Message"]:
         """Send audio files.
 
         For sending voice messages, use the :meth:`~pyrogram.Client.send_voice` method instead.

--- a/pyrogram/methods/messages/send_cached_media.py
+++ b/pyrogram/methods/messages/send_cached_media.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union, List
+from typing import Union, List, Optional
 
 from pyrogram import raw
 from pyrogram import types
@@ -30,7 +30,7 @@ class SendCachedMedia(Scaffold):
         chat_id: Union[int, str],
         file_id: str,
         caption: str = "",
-        parse_mode: Union[str, None] = object,
+        parse_mode: Optional[str] = object,
         caption_entities: List["types.MessageEntity"] = None,
         disable_notification: bool = None,
         reply_to_message_id: int = None,
@@ -41,7 +41,7 @@ class SendCachedMedia(Scaffold):
             "types.ReplyKeyboardRemove",
             "types.ForceReply"
         ] = None
-    ) -> Union["types.Message", None]:
+    ) -> Optional["types.Message"]:
         """Send any media stored on the Telegram servers using a file_id.
 
         This convenience method works with any valid file_id only.

--- a/pyrogram/methods/messages/send_dice.py
+++ b/pyrogram/methods/messages/send_dice.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from typing import Union, Optional
 
 from pyrogram import raw
 from pyrogram import types
@@ -37,7 +37,7 @@ class SendDice(Scaffold):
             "types.ReplyKeyboardRemove",
             "types.ForceReply"
         ] = None
-    ) -> Union["types.Message", None]:
+    ) -> Optional["types.Message"]:
         """Send a dice with a random value from 1 to 6.
 
         Parameters:

--- a/pyrogram/methods/messages/send_document.py
+++ b/pyrogram/methods/messages/send_document.py
@@ -18,7 +18,7 @@
 
 import os
 import re
-from typing import Union, BinaryIO, List
+from typing import Union, BinaryIO, List, Optional
 
 from pyrogram import StopTransmission
 from pyrogram import raw
@@ -36,7 +36,7 @@ class SendDocument(Scaffold):
         document: Union[str, BinaryIO],
         thumb: Union[str, BinaryIO] = None,
         caption: str = "",
-        parse_mode: Union[str, None] = object,
+        parse_mode: Optional[str] = object,
         caption_entities: List["types.MessageEntity"] = None,
         file_name: str = None,
         force_document: bool = None,
@@ -51,7 +51,7 @@ class SendDocument(Scaffold):
         ] = None,
         progress: callable = None,
         progress_args: tuple = ()
-    ) -> Union["types.Message", None]:
+    ) -> Optional["types.Message"]:
         """Send generic files.
 
         Parameters:

--- a/pyrogram/methods/messages/send_message.py
+++ b/pyrogram/methods/messages/send_message.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union, List
+from typing import Union, List, Optional
 
 from pyrogram import raw, utils
 from pyrogram import types
@@ -28,7 +28,7 @@ class SendMessage(Scaffold):
         self,
         chat_id: Union[int, str],
         text: str,
-        parse_mode: Union[str, None] = object,
+        parse_mode: Optional[str] = object,
         entities: List["types.MessageEntity"] = None,
         disable_web_page_preview: bool = None,
         disable_notification: bool = None,

--- a/pyrogram/methods/messages/send_photo.py
+++ b/pyrogram/methods/messages/send_photo.py
@@ -18,7 +18,7 @@
 
 import os
 import re
-from typing import Union, BinaryIO, List
+from typing import Union, BinaryIO, List, Optional
 
 import pyrogram
 from pyrogram import raw
@@ -35,7 +35,7 @@ class SendPhoto(Scaffold):
         chat_id: Union[int, str],
         photo: Union[str, BinaryIO],
         caption: str = "",
-        parse_mode: Union[str, None] = object,
+        parse_mode: Optional[str] = object,
         caption_entities: List["types.MessageEntity"] = None,
         ttl_seconds: int = None,
         disable_notification: bool = None,
@@ -49,7 +49,7 @@ class SendPhoto(Scaffold):
         ] = None,
         progress: callable = None,
         progress_args: tuple = ()
-    ) -> Union["types.Message", None]:
+    ) -> Optional["types.Message"]:
         """Send photos.
 
         Parameters:

--- a/pyrogram/methods/messages/send_sticker.py
+++ b/pyrogram/methods/messages/send_sticker.py
@@ -18,7 +18,7 @@
 
 import os
 import re
-from typing import Union, BinaryIO
+from typing import Union, BinaryIO, Optional
 
 from pyrogram import StopTransmission
 from pyrogram import raw
@@ -45,7 +45,7 @@ class SendSticker(Scaffold):
         ] = None,
         progress: callable = None,
         progress_args: tuple = ()
-    ) -> Union["types.Message", None]:
+    ) -> Optional["types.Message"]:
         """Send static .webp or animated .tgs stickers.
 
         Parameters:

--- a/pyrogram/methods/messages/send_video.py
+++ b/pyrogram/methods/messages/send_video.py
@@ -18,7 +18,7 @@
 
 import os
 import re
-from typing import Union, BinaryIO, List
+from typing import Union, BinaryIO, List, Optional
 
 from pyrogram import StopTransmission
 from pyrogram import raw
@@ -35,7 +35,7 @@ class SendVideo(Scaffold):
         chat_id: Union[int, str],
         video: Union[str, BinaryIO],
         caption: str = "",
-        parse_mode: Union[str, None] = object,
+        parse_mode: Optional[str] = object,
         caption_entities: List["types.MessageEntity"] = None,
         ttl_seconds: int = None,
         duration: int = 0,
@@ -55,7 +55,7 @@ class SendVideo(Scaffold):
         ] = None,
         progress: callable = None,
         progress_args: tuple = ()
-    ) -> Union["types.Message", None]:
+    ) -> Optional["types.Message"]:
         """Send video files.
 
         Parameters:

--- a/pyrogram/methods/messages/send_video_note.py
+++ b/pyrogram/methods/messages/send_video_note.py
@@ -17,7 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-from typing import Union, BinaryIO
+from typing import Union, BinaryIO, Optional
 
 from pyrogram import StopTransmission
 from pyrogram import raw
@@ -47,7 +47,7 @@ class SendVideoNote(Scaffold):
         ] = None,
         progress: callable = None,
         progress_args: tuple = ()
-    ) -> Union["types.Message", None]:
+    ) -> Optional["types.Message"]:
         """Send video messages.
 
         Parameters:

--- a/pyrogram/methods/messages/send_voice.py
+++ b/pyrogram/methods/messages/send_voice.py
@@ -18,7 +18,7 @@
 
 import os
 import re
-from typing import Union, BinaryIO, List
+from typing import Union, BinaryIO, List, Optional
 
 from pyrogram import StopTransmission
 from pyrogram import raw
@@ -35,7 +35,7 @@ class SendVoice(Scaffold):
         chat_id: Union[int, str],
         voice: Union[str, BinaryIO],
         caption: str = "",
-        parse_mode: Union[str, None] = object,
+        parse_mode: Optional[str] = object,
         caption_entities: List["types.MessageEntity"] = None,
         duration: int = 0,
         disable_notification: bool = None,
@@ -49,7 +49,7 @@ class SendVoice(Scaffold):
         ] = None,
         progress: callable = None,
         progress_args: tuple = ()
-    ) -> Union["types.Message", None]:
+    ) -> Optional["types.Message"]:
         """Send audio files.
 
         Parameters:

--- a/pyrogram/methods/users/update_username.py
+++ b/pyrogram/methods/users/update_username.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from typing import Optional
 
 from pyrogram import raw
 from pyrogram.scaffold import Scaffold
@@ -25,7 +25,7 @@ from pyrogram.scaffold import Scaffold
 class UpdateUsername(Scaffold):
     async def update_username(
         self,
-        username: Union[str, None]
+        username: Optional[str]
     ) -> bool:
         """Update your own username.
 

--- a/pyrogram/parser/html.py
+++ b/pyrogram/parser/html.py
@@ -20,7 +20,7 @@ import html
 import logging
 import re
 from html.parser import HTMLParser
-from typing import Union
+from typing import Optional
 
 import pyrogram
 from pyrogram import raw
@@ -106,7 +106,7 @@ class Parser(HTMLParser):
 
 
 class HTML:
-    def __init__(self, client: Union["pyrogram.Client", None]):
+    def __init__(self, client: Optional["pyrogram.Client"]):
         self.client = client
 
     async def parse(self, text: str):

--- a/pyrogram/parser/markdown.py
+++ b/pyrogram/parser/markdown.py
@@ -18,7 +18,7 @@
 
 import html
 import re
-from typing import Union
+from typing import Optional
 
 import pyrogram
 from . import utils
@@ -53,7 +53,7 @@ FIXED_WIDTH_DELIMS = [CODE_DELIM, PRE_DELIM]
 
 
 class Markdown:
-    def __init__(self, client: Union["pyrogram.Client", None]):
+    def __init__(self, client: Optional["pyrogram.Client"]):
         self.html = HTML(client)
 
     async def parse(self, text: str, strict: bool = False):

--- a/pyrogram/parser/parser.py
+++ b/pyrogram/parser/parser.py
@@ -17,7 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 from collections import OrderedDict
-from typing import Union
+from typing import Optional
 
 import pyrogram
 from .html import HTML
@@ -25,12 +25,12 @@ from .markdown import Markdown
 
 
 class Parser:
-    def __init__(self, client: Union["pyrogram.Client", None]):
+    def __init__(self, client: Optional["pyrogram.Client"]):
         self.client = client
         self.html = HTML(client)
         self.markdown = Markdown(client)
 
-    async def parse(self, text: str, mode: Union[str, None] = object):
+    async def parse(self, text: str, mode: Optional[str] = object):
         text = str(text).strip()
 
         if mode == object:

--- a/pyrogram/types/bots_and_keyboards/callback_query.py
+++ b/pyrogram/types/bots_and_keyboards/callback_query.py
@@ -18,7 +18,7 @@
 
 from base64 import b64encode
 from struct import pack
-from typing import Union, List, Match
+from typing import Union, List, Match, Optional
 
 import pyrogram
 from pyrogram import raw
@@ -171,7 +171,7 @@ class CallbackQuery(Object, Update):
     async def edit_message_text(
         self,
         text: str,
-        parse_mode: Union[str, None] = object,
+        parse_mode: Optional[str] = object,
         disable_web_page_preview: bool = None,
         reply_markup: "types.InlineKeyboardMarkup" = None
     ) -> Union["types.Message", bool]:
@@ -224,7 +224,7 @@ class CallbackQuery(Object, Update):
     async def edit_message_caption(
         self,
         caption: str,
-        parse_mode: Union[str, None] = object,
+        parse_mode: Optional[str] = object,
         reply_markup: "types.InlineKeyboardMarkup" = None
     ) -> Union["types.Message", bool]:
         """Edit the caption of media messages attached to callback queries.

--- a/pyrogram/types/inline_mode/inline_query_result_animation.py
+++ b/pyrogram/types/inline_mode/inline_query_result_animation.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from typing import Optional
 
 from pyrogram import raw
 from pyrogram import types
@@ -75,7 +75,7 @@ class InlineQueryResultAnimation(InlineQueryResult):
         title: str = None,
         description: str = None,
         caption: str = "",
-        parse_mode: Union[str, None] = object,
+        parse_mode: Optional[str] = object,
         reply_markup: "types.InlineKeyboardMarkup" = None,
         input_message_content: "types.InputMessageContent" = None
     ):

--- a/pyrogram/types/inline_mode/inline_query_result_photo.py
+++ b/pyrogram/types/inline_mode/inline_query_result_photo.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from typing import Optional
 
 from pyrogram import raw
 from pyrogram import types
@@ -75,7 +75,7 @@ class InlineQueryResultPhoto(InlineQueryResult):
         title: str = None,
         description: str = None,
         caption: str = "",
-        parse_mode: Union[str, None] = object,
+        parse_mode: Optional[str] = object,
         reply_markup: "types.InlineKeyboardMarkup" = None,
         input_message_content: "types.InputMessageContent" = None
     ):

--- a/pyrogram/types/input_media/input_media_animation.py
+++ b/pyrogram/types/input_media/input_media_animation.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union, List
+from typing import Optional, List
 
 from .input_media import InputMedia
 from ..messages_and_media import MessageEntity
@@ -65,7 +65,7 @@ class InputMediaAnimation(InputMedia):
         media: str,
         thumb: str = None,
         caption: str = "",
-        parse_mode: Union[str, None] = object,
+        parse_mode: Optional[str] = object,
         caption_entities: List[MessageEntity] = None,
         width: int = 0,
         height: int = 0,

--- a/pyrogram/types/input_media/input_media_audio.py
+++ b/pyrogram/types/input_media/input_media_audio.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union, List
+from typing import Optional, List
 
 from .input_media import InputMedia
 from ..messages_and_media import MessageEntity
@@ -67,7 +67,7 @@ class InputMediaAudio(InputMedia):
         media: str,
         thumb: str = None,
         caption: str = "",
-        parse_mode: Union[str, None] = object,
+        parse_mode: Optional[str] = object,
         caption_entities: List[MessageEntity] = None,
         duration: int = 0,
         performer: str = "",

--- a/pyrogram/types/input_media/input_media_document.py
+++ b/pyrogram/types/input_media/input_media_document.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union, List
+from typing import Optional, List
 
 from .input_media import InputMedia
 from ..messages_and_media import MessageEntity
@@ -56,7 +56,7 @@ class InputMediaDocument(InputMedia):
         media: str,
         thumb: str = None,
         caption: str = "",
-        parse_mode: Union[str, None] = object,
+        parse_mode: Optional[str] = object,
         caption_entities: List[MessageEntity] = None
     ):
         super().__init__(media, caption, parse_mode, caption_entities)

--- a/pyrogram/types/input_media/input_media_photo.py
+++ b/pyrogram/types/input_media/input_media_photo.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union, List
+from typing import Optional, List
 
 from .input_media import InputMedia
 from ..messages_and_media import MessageEntity
@@ -51,7 +51,7 @@ class InputMediaPhoto(InputMedia):
         self,
         media: str,
         caption: str = "",
-        parse_mode: Union[str, None] = object,
+        parse_mode: Optional[str] = object,
         caption_entities: List[MessageEntity] = None
     ):
         super().__init__(media, caption, parse_mode, caption_entities)

--- a/pyrogram/types/input_media/input_media_video.py
+++ b/pyrogram/types/input_media/input_media_video.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union, List
+from typing import Optional, List
 
 from .input_media import InputMedia
 from ..messages_and_media import MessageEntity
@@ -70,7 +70,7 @@ class InputMediaVideo(InputMedia):
         media: str,
         thumb: str = None,
         caption: str = "",
-        parse_mode: Union[str, None] = object,
+        parse_mode: Optional[str] = object,
         caption_entities: List[MessageEntity] = None,
         width: int = 0,
         height: int = 0,

--- a/pyrogram/types/input_message_content/input_text_message_content.py
+++ b/pyrogram/types/input_message_content/input_text_message_content.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from typing import Optional
 
 from pyrogram import raw
 from pyrogram.parser import Parser
@@ -41,7 +41,7 @@ class InputTextMessageContent(InputMessageContent):
             Disables link previews for links in this message.
     """
 
-    def __init__(self, message_text: str, parse_mode: Union[str, None] = object, disable_web_page_preview: bool = None):
+    def __init__(self, message_text: str, parse_mode: Optional[str] = object, disable_web_page_preview: bool = None):
         super().__init__()
 
         self.message_text = message_text

--- a/pyrogram/types/messages_and_media/message.py
+++ b/pyrogram/types/messages_and_media/message.py
@@ -2711,7 +2711,7 @@ class Message(Object, Update):
 
     async def forward(
         self,
-        chat_id: int or str,
+        chat_id: Union[int, str],
         disable_notification: bool = None,
         schedule_date: int = None
     ) -> Union["types.Message", List["types.Message"]]:
@@ -2975,7 +2975,7 @@ class Message(Object, Update):
             revoke=revoke
         )
 
-    async def click(self, x: int or str = 0, y: int = None, quote: bool = None, timeout: int = 10):
+    async def click(self, x: Union[int, str] = 0, y: int = None, quote: bool = None, timeout: int = 10):
         """Bound method *click* of :obj:`~pyrogram.types.Message`.
 
         Use as a shortcut for clicking a button attached to the message instead of:

--- a/pyrogram/types/messages_and_media/message.py
+++ b/pyrogram/types/messages_and_media/message.py
@@ -2763,7 +2763,7 @@ class Message(Object, Update):
         self,
         chat_id: Union[int, str],
         caption: str = None,
-        parse_mode: Union[str, None] = object,
+        parse_mode: Optional[str] = object,
         caption_entities: List["types.MessageEntity"] = None,
         disable_notification: bool = None,
         reply_to_message_id: int = None,

--- a/pyrogram/types/messages_and_media/message.py
+++ b/pyrogram/types/messages_and_media/message.py
@@ -18,7 +18,7 @@
 
 import logging
 from functools import partial
-from typing import List, Match, Union, BinaryIO
+from typing import List, Match, Union, BinaryIO, Optional
 
 import pyrogram
 from pyrogram import raw
@@ -710,7 +710,7 @@ class Message(Object, Update):
         self,
         text: str,
         quote: bool = None,
-        parse_mode: Union[str, None] = object,
+        parse_mode: Optional[str] = object,
         entities: List["types.MessageEntity"] = None,
         disable_web_page_preview: bool = None,
         disable_notification: bool = None,
@@ -797,7 +797,7 @@ class Message(Object, Update):
         animation: Union[str, BinaryIO],
         quote: bool = None,
         caption: str = "",
-        parse_mode: Union[str, None] = object,
+        parse_mode: Optional[str] = object,
         caption_entities: List["types.MessageEntity"] = None,
         duration: int = 0,
         width: int = 0,
@@ -939,7 +939,7 @@ class Message(Object, Update):
         audio: Union[str, BinaryIO],
         quote: bool = None,
         caption: str = "",
-        parse_mode: Union[str, None] = object,
+        parse_mode: Optional[str] = object,
         caption_entities: List["types.MessageEntity"] = None,
         duration: int = 0,
         performer: str = None,
@@ -1081,7 +1081,7 @@ class Message(Object, Update):
         file_id: str,
         quote: bool = None,
         caption: str = "",
-        parse_mode: Union[str, None] = object,
+        parse_mode: Optional[str] = object,
         caption_entities: List["types.MessageEntity"] = None,
         disable_notification: bool = None,
         reply_to_message_id: int = None,
@@ -1294,7 +1294,7 @@ class Message(Object, Update):
         quote: bool = None,
         thumb: str = None,
         caption: str = "",
-        parse_mode: Union[str, None] = object,
+        parse_mode: Optional[str] = object,
         caption_entities: List["types.MessageEntity"] = None,
         disable_notification: bool = None,
         reply_to_message_id: int = None,
@@ -1694,7 +1694,7 @@ class Message(Object, Update):
         photo: Union[str, BinaryIO],
         quote: bool = None,
         caption: str = "",
-        parse_mode: Union[str, None] = object,
+        parse_mode: Optional[str] = object,
         caption_entities: List["types.MessageEntity"] = None,
         ttl_seconds: int = None,
         disable_notification: bool = None,
@@ -2122,7 +2122,7 @@ class Message(Object, Update):
         video: Union[str, BinaryIO],
         quote: bool = None,
         caption: str = "",
-        parse_mode: Union[str, None] = object,
+        parse_mode: Optional[str] = object,
         caption_entities: List["types.MessageEntity"] = None,
         ttl_seconds: int = None,
         duration: int = 0,
@@ -2394,7 +2394,7 @@ class Message(Object, Update):
         voice: Union[str, BinaryIO],
         quote: bool = None,
         caption: str = "",
-        parse_mode: Union[str, None] = object,
+        parse_mode: Optional[str] = object,
         caption_entities: List["types.MessageEntity"] = None,
         duration: int = 0,
         disable_notification: bool = None,
@@ -2516,7 +2516,7 @@ class Message(Object, Update):
     async def edit_text(
         self,
         text: str,
-        parse_mode: Union[str, None] = object,
+        parse_mode: Optional[str] = object,
         entities: List["types.MessageEntity"] = None,
         disable_web_page_preview: bool = None,
         reply_markup: "types.InlineKeyboardMarkup" = None
@@ -2579,7 +2579,7 @@ class Message(Object, Update):
     async def edit_caption(
         self,
         caption: str,
-        parse_mode: Union[str, None] = object,
+        parse_mode: Optional[str] = object,
         caption_entities: List["types.MessageEntity"] = None,
         reply_markup: "types.InlineKeyboardMarkup" = None
     ) -> "Message":

--- a/pyrogram/types/messages_and_media/message_entity.py
+++ b/pyrogram/types/messages_and_media/message_entity.py
@@ -17,6 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 from enum import Enum, auto
+from typing import Union
 
 import pyrogram
 from pyrogram import raw
@@ -121,7 +122,7 @@ class MessageEntity(Object):
         self.language = language
 
     @staticmethod
-    def _parse(client, entity, users: dict) -> "MessageEntity" or None:
+    def _parse(client, entity, users: dict) -> Union["MessageEntity", None]:
         type = RAW_ENTITIES_TO_TYPE.get(entity.__class__, None)
 
         if type is None:

--- a/pyrogram/types/messages_and_media/message_entity.py
+++ b/pyrogram/types/messages_and_media/message_entity.py
@@ -17,7 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 from enum import Enum, auto
-from typing import Union
+from typing import Optional
 
 import pyrogram
 from pyrogram import raw
@@ -122,7 +122,7 @@ class MessageEntity(Object):
         self.language = language
 
     @staticmethod
-    def _parse(client, entity, users: dict) -> Union["MessageEntity", None]:
+    def _parse(client, entity, users: dict) -> Optional["MessageEntity"]:
         type = RAW_ENTITIES_TO_TYPE.get(entity.__class__, None)
 
         if type is None:

--- a/pyrogram/types/messages_and_media/thumbnail.py
+++ b/pyrogram/types/messages_and_media/thumbnail.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union, List
+from typing import Union, List, Optional
 
 import pyrogram
 from pyrogram import raw
@@ -68,7 +68,7 @@ class Thumbnail(Object):
     def _parse(
         client,
         media: Union["raw.types.Photo", "raw.types.Document"]
-    ) -> Union[List[Union["types.StrippedThumbnail", "Thumbnail"]], None]:
+    ) -> Optional[List[Union["types.StrippedThumbnail", "Thumbnail"]]]:
         if isinstance(media, raw.types.Photo):
             raw_thumbnails = media.sizes[:-1]
         elif isinstance(media, raw.types.Document):

--- a/pyrogram/types/user_and_chats/chat.py
+++ b/pyrogram/types/user_and_chats/chat.py
@@ -229,7 +229,7 @@ class Chat(Object):
         )
 
     @staticmethod
-    def _parse(client, message: raw.types.Message or raw.types.MessageService, users: dict, chats: dict) -> "Chat":
+    def _parse(client, message: Union[raw.types.Message, raw.types.MessageService], users: dict, chats: dict) -> "Chat":
         if isinstance(message.peer_id, raw.types.PeerUser):
             return Chat._parse_user_chat(client, users[message.peer_id.user_id])
 
@@ -248,7 +248,7 @@ class Chat(Object):
             return Chat._parse_channel_chat(client, chats[peer.channel_id])
 
     @staticmethod
-    async def _parse_full(client, chat_full: raw.types.messages.ChatFull or raw.types.UserFull) -> "Chat":
+    async def _parse_full(client, chat_full: Union[raw.types.messages.ChatFull, raw.types.UserFull]) -> "Chat":
         if isinstance(chat_full, raw.types.UserFull):
             parsed_chat = Chat._parse_user_chat(client, chat_full.user)
             parsed_chat.bio = chat_full.about

--- a/pyrogram/types/user_and_chats/user.py
+++ b/pyrogram/types/user_and_chats/user.py
@@ -17,7 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 import html
-from typing import List, Union
+from typing import List, Optional
 
 import pyrogram
 from pyrogram import raw
@@ -201,7 +201,7 @@ class User(Object, Update):
         return Link(f"tg://user?id={self.id}", self.first_name, self._client.parse_mode)
 
     @staticmethod
-    def _parse(client, user: "raw.types.User") -> Union["User", None]:
+    def _parse(client, user: "raw.types.User") -> Optional["User"]:
         if user is None:
             return None
 

--- a/pyrogram/types/user_and_chats/user.py
+++ b/pyrogram/types/user_and_chats/user.py
@@ -17,7 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 import html
-from typing import List
+from typing import List, Union
 
 import pyrogram
 from pyrogram import raw
@@ -201,7 +201,7 @@ class User(Object, Update):
         return Link(f"tg://user?id={self.id}", self.first_name, self._client.parse_mode)
 
     @staticmethod
-    def _parse(client, user: "raw.types.User") -> "User" or None:
+    def _parse(client, user: "raw.types.User") -> Union["User", None]:
         if user is None:
             return None
 

--- a/pyrogram/utils.py
+++ b/pyrogram/utils.py
@@ -24,7 +24,7 @@ import os
 import struct
 from concurrent.futures.thread import ThreadPoolExecutor
 from getpass import getpass
-from typing import Union, List, Dict
+from typing import Union, List, Dict, Optional
 
 import pyrogram
 from pyrogram import raw
@@ -168,7 +168,7 @@ MIN_CHAT_ID = -2147483647
 MAX_USER_ID = 2147483647
 
 
-def get_raw_peer_id(peer: raw.base.Peer) -> Union[int, None]:
+def get_raw_peer_id(peer: raw.base.Peer) -> Optional[int]:
     """Get the raw peer id from a Peer object"""
     if isinstance(peer, raw.types.PeerUser):
         return peer.user_id


### PR DESCRIPTION
### Proposed changes
 - Change `type1 or type2` to `Union[type1, type2]` because the first one is not a valid syntax for typing hints (though it does not give any SyntaxError).
 - Change `Union[type1, None]` to `Optional[type1]` as proposed in https://github.com/pyrogram/pyrogram/pull/537#pullrequestreview-540450312.