### PR TITLE
added cached media support in inline query

### DIFF
--- a/pyrogram/types/inline_mode/__init__.py
+++ b/pyrogram/types/inline_mode/__init__.py
@@ -22,6 +22,8 @@ from .inline_query_result import InlineQueryResult
 from .inline_query_result_animation import InlineQueryResultAnimation
 from .inline_query_result_article import InlineQueryResultArticle
 from .inline_query_result_photo import InlineQueryResultPhoto
+from .inline_query_result_cached_photo import InlineQueryResultCachedPhoto
+from .inline_query_result_cached_document import InlineQueryResultCachedDocument
 
 __all__ = [
     "InlineQuery", "InlineQueryResult", "InlineQueryResultArticle", "InlineQueryResultPhoto",

--- a/pyrogram/types/inline_mode/__init__.py
+++ b/pyrogram/types/inline_mode/__init__.py
@@ -25,5 +25,6 @@ from .inline_query_result_photo import InlineQueryResultPhoto
 
 __all__ = [
     "InlineQuery", "InlineQueryResult", "InlineQueryResultArticle", "InlineQueryResultPhoto",
-    "InlineQueryResultAnimation", "ChosenInlineResult"
+    "InlineQueryResultAnimation", "InlineQueryResultCachedPhoto", "InlineQueryResultCachedDocument",
+    "ChosenInlineResult",
 ]

--- a/pyrogram/types/inline_mode/inline_query_result_cached_document.py
+++ b/pyrogram/types/inline_mode/inline_query_result_cached_document.py
@@ -26,8 +26,45 @@ from .inline_query_result import InlineQueryResult
 
 
 class InlineQueryResultCachedDocument(InlineQueryResult):
+    """Link to a file stored on the Telegram servers.
 
-    # TODO: Need to add documentation (supports all cached media except photo)
+    By default, this file will be sent by the user with an optional caption. 
+    Alternatively, you can use input_message_content to send a message with the specified content instead of the file.
+
+    Parameters:
+        title (``str``):
+            Title for the result.
+        
+        file_id (``str``):
+            Pass a file_id as string to send a media that exists on the Telegram servers.
+
+        file_ref (``str``, *optional*):
+            A valid file reference obtained by a recently fetched media message.
+            To be used in combination with a file id in case a file reference is needed.
+
+        id (``str``, *optional*):
+            Unique identifier for this result, 1-64 bytes.
+            Defaults to a randomly generated UUID4.
+
+        description (``str``, *optional*):
+            Short description of the result.
+
+        caption (``str``, *optional*):
+            Caption of the photo to be sent, 0-1024 characters.
+        
+        parse_mode (``str``, *optional*):
+            By default, texts are parsed using both Markdown and HTML styles.
+            You can combine both syntaxes together.
+            Pass "markdown" or "md" to enable Markdown-style parsing only.
+            Pass "html" to enable HTML-style parsing only.
+            Pass None to completely disable style parsing.
+
+        reply_markup (:obj:`~pyrogram.types.InlineKeyboardMarkup`, *optional*):
+            Inline keyboard attached to the message.
+
+        input_message_content (:obj:`~pyrogram.types.InputMessageContent`):
+            Content of the message to be sent.
+    """
 
     def __init__(
         self,

--- a/pyrogram/types/inline_mode/inline_query_result_cached_document.py
+++ b/pyrogram/types/inline_mode/inline_query_result_cached_document.py
@@ -1,0 +1,72 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-2020 Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
+
+from typing import Union
+
+from pyrogram import raw
+from pyrogram import utils
+from pyrogram import types
+from pyrogram.parser import Parser
+from .inline_query_result import InlineQueryResult
+
+
+class InlineQueryResultCachedDocument(InlineQueryResult):
+
+    # TODO: Need to add documentation (supports all cached media except photo)
+
+    def __init__(
+        self,
+        title: str,
+        file_id: str,
+        file_ref: str = None,
+        id: str = None,
+        description: str = None,
+        caption: str = "",
+        parse_mode: Union[str, None] = object,
+        reply_markup: "types.InlineKeyboardMarkup" = None,
+        input_message_content: "types.InputMessageContent" = None
+    ):
+        super().__init__("file", id, input_message_content, reply_markup)
+
+        self.file_id = file_id
+        self.file_ref = file_ref
+        self.title = title
+        self.description = description
+        self.caption = caption
+        self.parse_mode = parse_mode
+        self.reply_markup = reply_markup
+        self.input_message_content = input_message_content
+
+    async def write(self):
+        document = utils.get_input_file_from_file_id(self.file_id, self.file_ref)
+
+        return raw.types.InputBotInlineResultDocument(
+            id=self.id,
+            type=self.type,
+            title=self.title,
+            description=self.description,
+            document=document,
+            send_message=(
+                await self.input_message_content.write(self.reply_markup)
+                if self.input_message_content
+                else raw.types.InputBotInlineMessageMediaAuto(
+                    reply_markup=self.reply_markup.write() if self.reply_markup else None,
+                    **await(Parser(None)).parse(self.caption, self.parse_mode)
+                )
+            )
+        ) 

--- a/pyrogram/types/inline_mode/inline_query_result_cached_photo.py
+++ b/pyrogram/types/inline_mode/inline_query_result_cached_photo.py
@@ -26,8 +26,39 @@ from .inline_query_result import InlineQueryResult
 
 
 class InlineQueryResultCachedPhoto(InlineQueryResult):
+    """Link to a photo stored on the Telegram servers.
 
-    # TODO: Need to add documentation 
+    By default, this photo will be sent by the user with an optional caption. 
+    Alternatively, you can use input_message_content to send a message with the specified content instead of the photo.
+
+    Parameters:
+        file_id (``str``):
+            Pass a file_id as string to send a media that exists on the Telegram servers.
+
+        file_ref (``str``, *optional*):
+            A valid file reference obtained by a recently fetched media message.
+            To be used in combination with a file id in case a file reference is needed.
+
+        id (``str``, *optional*):
+            Unique identifier for this result, 1-64 bytes.
+            Defaults to a randomly generated UUID4.
+
+        caption (``str``, *optional*):
+            Caption of the photo to be sent, 0-1024 characters.
+        
+        parse_mode (``str``, *optional*):
+            By default, texts are parsed using both Markdown and HTML styles.
+            You can combine both syntaxes together.
+            Pass "markdown" or "md" to enable Markdown-style parsing only.
+            Pass "html" to enable HTML-style parsing only.
+            Pass None to completely disable style parsing.
+
+        reply_markup (:obj:`~pyrogram.types.InlineKeyboardMarkup`, *optional*):
+            Inline keyboard attached to the message.
+
+        input_message_content (:obj:`~pyrogram.types.InputMessageContent`):
+            Content of the message to be sent.
+    """
 
     def __init__(
         self,

--- a/pyrogram/types/inline_mode/inline_query_result_cached_photo.py
+++ b/pyrogram/types/inline_mode/inline_query_result_cached_photo.py
@@ -1,0 +1,66 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-2020 Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
+
+from typing import Union
+
+from pyrogram import raw
+from pyrogram import utils
+from pyrogram import types
+from pyrogram.parser import Parser
+from .inline_query_result import InlineQueryResult
+
+
+class InlineQueryResultCachedPhoto(InlineQueryResult):
+
+    # TODO: Need to add documentation 
+
+    def __init__(
+        self,
+        file_id: str,
+        file_ref: str = None,
+        id: str = None,
+        caption: str = "",
+        parse_mode: Union[str, None] = object,
+        reply_markup: "types.InlineKeyboardMarkup" = None,
+        input_message_content: "types.InputMessageContent" = None
+    ):
+        super().__init__("photo", id, input_message_content, reply_markup)
+
+        self.file_id = file_id
+        self.file_ref = file_ref
+        self.caption = caption
+        self.parse_mode = parse_mode
+        self.reply_markup = reply_markup
+        self.input_message_content = input_message_content
+
+    async def write(self):
+        photo = utils.get_input_file_from_file_id(self.file_id, self.file_ref, 2)
+
+        return raw.types.InputBotInlineResultPhoto(
+            id=self.id,
+            type=self.type,
+            photo=photo,
+            send_message=(
+                await self.input_message_content.write(self.reply_markup)
+                if self.input_message_content
+                else raw.types.InputBotInlineMessageMediaAuto(
+                    reply_markup=self.reply_markup.write() if self.reply_markup else None,
+                    **await(Parser(None)).parse(self.caption, self.parse_mode)
+                )
+            )
+        )  

--- a/pyrogram/utils.py
+++ b/pyrogram/utils.py
@@ -150,6 +150,51 @@ def get_input_media_from_file_id(
         raise ValueError(f"Unknown media type: {file_id_str}")
 
 
+def get_input_file_from_file_id(
+    file_id_str: str,
+    file_ref: str = None,
+    expected_media_type: int = None
+) -> Union["raw.types.InputPhoto", "raw.types.InputDocument"]:
+    try:
+        decoded = decode_file_id(file_id_str)
+    except Exception:
+        raise ValueError(f"Failed to decode file_id: {file_id_str}")
+    else:
+        media_type = decoded[0]
+
+        if expected_media_type is not None:
+            if media_type != expected_media_type:
+                media_type_str = Scaffold.MEDIA_TYPE_ID.get(media_type, None)
+                expected_media_type_str = Scaffold.MEDIA_TYPE_ID.get(expected_media_type, None)
+
+                raise ValueError(f'Expected: "{expected_media_type_str}", got "{media_type_str}" file_id instead')
+
+        if media_type in (0, 1, 14):
+            raise ValueError(f"This file_id can only be used for download: {file_id_str}")
+
+        if media_type == 2:
+            unpacked = struct.unpack("<iiqqqiiii", decoded)
+            file_id, access_hash = unpacked[2:4]
+
+            return raw.types.InputPhoto(
+                id=file_id,
+                access_hash=access_hash,
+                file_reference=decode_file_ref(file_ref)
+            )
+
+        if media_type in (3, 4, 5, 8, 9, 10, 13):
+            unpacked = struct.unpack("<iiqq", decoded)
+            file_id, access_hash = unpacked[2:4]
+
+            return raw.types.InputDocument(
+                id=file_id,
+                access_hash=access_hash,
+                file_reference=decode_file_ref(file_ref)
+            )
+
+        raise ValueError(f"Unknown media type: {file_id_str}")
+    
+    
 async def parse_messages(client, messages: "raw.types.messages.Messages", replies: int = 1) -> List["types.Message"]:
     users = {i.id: i for i in messages.users}
     chats = {i.id: i for i in messages.chats}


### PR DESCRIPTION
Add **InlineQueryResultCachedPhoto, InlineQueryResultCachedDocument**, so we can send files stored on the Telegram servers in inline query results with the help of file_ids