### PR TITLE
New method - get_media_group() 

### DIFF
--- a/compiler/docs/compiler.py
+++ b/compiler/docs/compiler.py
@@ -167,6 +167,7 @@ def pyrogram_api():
             send_chat_action
             delete_messages
             get_messages
+            get_media_group
             get_history
             get_history_count
             read_history

--- a/pyrogram/methods/messages/__init__.py
+++ b/pyrogram/methods/messages/__init__.py
@@ -29,6 +29,7 @@ from .edit_message_text import EditMessageText
 from .forward_messages import ForwardMessages
 from .get_history import GetHistory
 from .get_history_count import GetHistoryCount
+from .get_media_group import GetMediaGroup
 from .get_messages import GetMessages
 from .iter_history import IterHistory
 from .read_history import ReadHistory
@@ -64,6 +65,7 @@ class Messages(
     EditMessageText,
     ForwardMessages,
     GetHistory,
+    GetMediaGroup,
     GetMessages,
     SendAudio,
     SendChatAction,

--- a/pyrogram/methods/messages/get_media_group.py
+++ b/pyrogram/methods/messages/get_media_group.py
@@ -1,0 +1,38 @@
+import logging
+from typing import Union, List
+
+from pyrogram.scaffold import Scaffold
+from pyrogram.types import list
+
+log = logging.getLogger(__name__)
+
+
+class GetMediaGroup(Scaffold):
+    async def get_media_group(
+        self,
+        chat_id: Union[int, str],
+        message_id: int
+    ) -> List["types.Message"]:
+        """Get media group 
+
+        Parameters:
+            chat_id (``int`` | ``str``):
+                Unique identifier (int) or username (str) of the target chat.
+                For your personal cloud (Saved Messages) you can simply use "me" or "self".
+                For a contact that exists in your Telegram address book you can use his phone number (str).
+
+            message_id (int):
+                #TODO Pass one message of target media get_media_group
+        Returns:
+            List of :obj:`~pyrogram.types.Message`
+        Raises:
+            #TODO ValueError: In case message isn't related to media group. 
+        """
+        messages = await self.get_messages(chat_id, [msg_id for msg_id in range(message_id-9, message_id+10)], replies=0)
+
+        if messages[9].media_group_id:
+            media_group_id = messages[9].media_group_id
+        else:
+            raise ValueError("Message isn't related to media group") #TODO
+
+        return list.List(msg for msg in messages if msg.media_group_id == media_group_id)

--- a/pyrogram/methods/messages/get_media_group.py
+++ b/pyrogram/methods/messages/get_media_group.py
@@ -1,3 +1,21 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-2020 Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
+
 import logging
 from typing import Union, List
 

--- a/pyrogram/methods/messages/get_media_group.py
+++ b/pyrogram/methods/messages/get_media_group.py
@@ -31,26 +31,29 @@ class GetMediaGroup(Scaffold):
         chat_id: Union[int, str],
         message_id: int
     ) -> List["types.Message"]:
-        """Get media group 
-
+        """Get the media group a message belongs to.
+        
         Parameters:
             chat_id (``int`` | ``str``):
                 Unique identifier (int) or username (str) of the target chat.
                 For your personal cloud (Saved Messages) you can simply use "me" or "self".
                 For a contact that exists in your Telegram address book you can use his phone number (str).
 
-            message_id (int):
-                #TODO Pass one message of target media get_media_group
+            message_id (``int``):
+                The id of one of the messages that belong to the media group.
+                
         Returns:
-            List of :obj:`~pyrogram.types.Message`
+            List of :obj:`~pyrogram.types.Message`: On success, a list of messages of the media group is returned.
+            
         Raises:
-            #TODO ValueError: In case message isn't related to media group. 
+            ValueError: In case the passed message id doesn't belong to a media group.
         """
-        messages = await self.get_messages(chat_id, [msg_id for msg_id in range(message_id-9, message_id+10)], replies=0)
+        # There can be maximum 10 items in a media group. 
+        messages = await self.get_messages(chat_id, [msg_id for msg_id in range(message_id - 9, message_id + 10)], replies=0)
 
-        if messages[9].media_group_id:
-            media_group_id = messages[9].media_group_id
-        else:
-            raise ValueError("Message isn't related to media group") #TODO
+        media_group_id = messages[9].media_group_id
+
+        if media_group_id is None:
+            raise ValueError("The message doesn't belong to a media group")
 
         return list.List(msg for msg in messages if msg.media_group_id == media_group_id)


### PR DESCRIPTION
Method to get all media group messages knowing only one. Special thank to Danipulok (https://github.com/Danipulok) 

"Problems":
1) Docs
Doubt how to write correctly so I marked those lines with  "#TODO" + examples. 

2) Should it raises error in case it's passed "wrong" (not related to media group) message_id or just return an empty list? 

UPD(5.12.2020):
I just noticed that other media groups have media_group_id attribute too (playlists etc.)
So now I'm 100% sure this method supports all types of media groups(playlists, albums etc.)  as it should be :) 