### PR TITLE
Added options and flags to command filter

### DIFF
--- a/pyrogram/filters.py
+++ b/pyrogram/filters.py
@@ -728,6 +728,7 @@ def command(commands: str or List[str], prefixes: str or List[str] = "/",
     async def func(flt, _, message: Message):
         text = message.text or message.caption
         message.command = None
+        message.opts = None
 
         if not text:
             return False
@@ -753,27 +754,29 @@ def command(commands: str or List[str], prefixes: str or List[str] = "/",
                     for m in command_re.finditer(without_prefix[len(cmd):])
                 ]
 
-                message.command = { "raw" : [cmd] + list(match_list), # make a copy
+                message.command = [cmd] + list(match_list) # make a copy, keep this for compatibility
+
+                message.opts = { "raw" : [cmd] + list(match_list), # make a copy
                                     "flags" : [] }
 
                 i = 0
                 while i < len(match_list):
                     if match_list[i] in flt.flags:
-                        message.command["flags"].append(match_list.pop(i))
+                        message.opts["flags"].append(match_list.pop(i))
                         continue
                     op = False
                     for k in flt.options:
                         if match_list[i] in flt.options[k]:
                             op = True
                             match_list.pop(i)
-                            message.command[k] = match_list.pop(i)
+                            message.opts[k] = match_list.pop(i)
                             break
                     if not op:
                         i +=1
 
                 if len(match_list) > 0:
-                    message.command["cmd"] = match_list # everything not consumed
-                    message.command["arg"] = " ".join(match_list) # provide a joined argument already
+                    message.opts["cmd"] = match_list # everything not consumed
+                    message.opts["arg"] = " ".join(match_list) # provide a joined argument already
 
                 return True
 


### PR DESCRIPTION
I added a way to define options and flags to look for in the command text. Having just a list of words wasn't enough for complex commands.

I made it keep the old `message.command` list for compatibility, but having it as one dict would be nicer in my opinion.

Basically, now you can do

```py
@bot.on_message(filters.command(["somecmd"], ["."], options={
    "opt1" : ["-o", "-option"],
    "opt2" : ["-p", "-ption"]
}, flags=["-list", "-random"]))
async def my_cmd(client, message):
  if "opt1" in message.opts:
    somevalue = int(message.opts["opt1"]
  if "-list" in message.opts["flags"]:
    # do something else
```