### PR TITLE
Don't process MessageEmpty in get_dialogs

### DIFF
--- a/pyrogram/methods/chats/get_dialogs.py
+++ b/pyrogram/methods/chats/get_dialogs.py
@@ -89,7 +89,7 @@ class GetDialogs(Scaffold):
         messages = {}
 
         for message in r.messages:
-            if message.empty:
+            if isinstance(message, raw.types.MessageEmpty):
                 continue
             
             peer_id = message.peer_id

--- a/pyrogram/methods/chats/get_dialogs.py
+++ b/pyrogram/methods/chats/get_dialogs.py
@@ -89,6 +89,9 @@ class GetDialogs(Scaffold):
         messages = {}
 
         for message in r.messages:
+            if message.empty:
+                continue
+            
             peer_id = message.peer_id
 
             if isinstance(peer_id, raw.types.PeerUser):


### PR DESCRIPTION
Prevent
```
  File "C:\Users\INT002327\AppData\Local\pypoetry\Cache\virtualenvs\josxabot-c3BmTbt9-py3.8\lib\site-packages\pyrogram\methods\chats\get_dialogs.py", line 92, in get_dialogs
    to_id = message.to_id
            └ pyrogram.raw.types.MessageEmpty(id=2767691)

AttributeError: 'MessageEmpty' object has no attribute 'to_id'
```