### PR TITLE
Get offset date from first non-null top message

### DIFF
--- a/pyrogram/methods/chats/iter_dialogs.py
+++ b/pyrogram/methods/chats/iter_dialogs.py
@@ -77,12 +77,15 @@ class IterDialogs(Scaffold):
 
             if not dialogs:
                 return
-
-            offset_date = dialogs[-1].top_message.date
+            
+            for d in dialogs[::-1]:
+                if d.top_message:
+                    offset_date = d.top_message.date
+                    break
 
             for dialog in dialogs:
                 yield dialog
-
+                
                 current += 1
 
                 if current >= total:


### PR DESCRIPTION
Fixes #536
Seems like `Dialog`s can have a `None` top message. This makes `iter_dialogs()` throw an exc when trying to access `date`. The loop is redundant and will hopefully very rarely run more than once, but should allow `iter_dialogs` to work even when top messages are missing without throwing an exc.