### PR TITLE
Make parse_mode always lowercase

### DIFF
--- a/pyrogram/client.py
+++ b/pyrogram/client.py
@@ -397,6 +397,8 @@ class Client(Methods, Scaffold):
 
     @parse_mode.setter
     def parse_mode(self, parse_mode: Optional[str] = "combined"):
+        if isinstance(parse_mode, str):
+            parse_mode = parse_mode.lower()
         if parse_mode not in self.PARSE_MODES:
             raise ValueError('parse_mode must be one of {} or None. Not "{}"'.format(
                 ", ".join(f'"{m}"' for m in self.PARSE_MODES[:-1]),

--- a/pyrogram/client.py
+++ b/pyrogram/client.py
@@ -399,6 +399,7 @@ class Client(Methods, Scaffold):
     def parse_mode(self, parse_mode: Optional[str] = "combined"):
         if isinstance(parse_mode, str):
             parse_mode = parse_mode.lower()
+
         if parse_mode not in self.PARSE_MODES:
             raise ValueError('parse_mode must be one of {} or None. Not "{}"'.format(
                 ", ".join(f'"{m}"' for m in self.PARSE_MODES[:-1]),


### PR DESCRIPTION
Currently, you can specify an uppercase parse_mode in Pyrogram methods, but not in Client instance:

```python
c = Client("my_client", parse_mode="HTML")
```
fails with:
```
ValueError: parse_mode must be one of "combined", "markdown", "md", "html" or None. Not "HTML"
```

However, in Client methods it works fine:
```python
c.send_message("me", "<b>Hi!</b>", parse_mode="HTML")
```