### PR TITLE
Fix invalid inline message id

### DIFF
--- a/pyrogram/methods/messages/inline_session.py
+++ b/pyrogram/methods/messages/inline_session.py
@@ -26,13 +26,9 @@ from pyrogram.session.auth import Auth
 
 lock = Lock()
 session = None
-dest_dc_id = 4
 
 
 async def get_session(client: "pyrogram.Client", dc_id: int):
-    if dc_id != dest_dc_id:
-        return client
-
     if dc_id == await client.storage.dc_id():
         return client
 
@@ -43,8 +39,8 @@ async def get_session(client: "pyrogram.Client", dc_id: int):
             return session
 
         session = Session(
-            client, dest_dc_id,
-            await Auth(client, dest_dc_id, False).create(),
+            client, dc_id,
+            await Auth(client, dc_id, False).create(),
             False, is_media=True
         )
 
@@ -53,7 +49,7 @@ async def get_session(client: "pyrogram.Client", dc_id: int):
         for _ in range(3):
             exported_auth = await client.send(
                 raw.functions.auth.ExportAuthorization(
-                    dc_id=dest_dc_id
+                    dc_id=dc_id
                 )
             )
 


### PR DESCRIPTION
Fix for inline message id invalid when target dc is not dc4 or current dc