### PR TITLE
Add method client.copy_media_group

### DIFF
--- a/compiler/docs/compiler.py
+++ b/compiler/docs/compiler.py
@@ -144,6 +144,7 @@ def pyrogram_api():
             send_message
             forward_messages
             copy_message
+            copy_media_group
             send_photo
             send_audio
             send_document

--- a/pyrogram/methods/messages/__init__.py
+++ b/pyrogram/methods/messages/__init__.py
@@ -17,6 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 from .copy_message import CopyMessage
+from .copy_media_group import CopyMediaGroup
 from .delete_messages import DeleteMessages
 from .download_media import DownloadMedia
 from .edit_inline_caption import EditInlineCaption
@@ -98,6 +99,7 @@ class Messages(
     SendDice,
     SearchMessages,
     SearchGlobal,
-    CopyMessage
+    CopyMessage,
+    CopyMediaGroup
 ):
     pass

--- a/pyrogram/methods/messages/copy_media_group.py
+++ b/pyrogram/methods/messages/copy_media_group.py
@@ -1,0 +1,134 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-2021 Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
+
+from typing import Union, List, Optional
+
+from pyrogram import types, utils, raw
+from pyrogram.scaffold import Scaffold
+
+
+class CopyMediaGroup(Scaffold):
+    async def copy_media_group(
+        self,
+        chat_id: Union[int, str],
+        from_chat_id: Union[int, str],
+        message_id: int,
+        captions: Union[List[str], str] = None,
+        disable_notification: bool = None,
+        reply_to_message_id: int = None,
+        schedule_date: int = None,
+    ) -> List["types.Message"]:
+        """Copy media group.
+
+        Parameters:
+            chat_id (``int`` | ``str``):
+                Unique identifier (int) or username (str) of the target chat.
+                For your personal cloud (Saved Messages) you can simply use "me" or "self".
+                For a contact that exists in your Telegram address book you can use his phone number (str).
+
+            from_chat_id (``int`` | ``str``):
+                Unique identifier (int) or username (str) of the source chat where the original media group was sent.
+                For your personal cloud (Saved Messages) you can simply use "me" or "self".
+                For a contact that exists in your Telegram address book you can use his phone number (str).
+
+            message_id (``int``):
+                Message identifier in the chat specified in *from_chat_id*.
+
+            captions (``string`` or list of ``string`` , *optional*):
+                New caption for media, 0-1024 characters after entities parsing for each media.
+                If not specified, the original caption is kept.
+                Pass "" (empty string) to remove the caption.
+
+                If a ``string`` is passed, it becomes a caption only for the first media.
+                If a list of ``string`` passed, each element becomes caption for each media element.
+                You can pass ``None`` in list to keep the original caption. Please check examples.
+
+            disable_notification (``bool``, *optional*):
+                Sends the message silently.
+                Users will receive a notification with no sound.
+
+            reply_to_message_id (``int``, *optional*):
+                If the message is a reply, ID of the original message.
+
+            schedule_date (``int``, *optional*):
+                Date when the message will be automatically sent. Unix time.
+
+        Returns:
+            List of :obj:`~pyrogram.types.Message`: On success, a list of copied messages is returned.
+
+        Example:
+            .. code-block:: python
+
+                # Copy a media group
+                app.copy_media_group("me", "pyrogramlounge", 470061)
+                app.copy_media_group("me", "pyrogramlounge", 470061, captions="Single caption")
+                app.copy_media_group("me", "pyrogramlounge", 470061, captions=["Media 1 caption", None, ""])
+        """
+
+        media_group = await self.get_media_group(from_chat_id, message_id)
+        multi_media = []
+
+        for i, message in enumerate(media_group):
+
+            if message.photo:
+                file_id = message.photo.file_id
+            elif message.audio:
+                file_id = message.audio.file_id
+            elif message.document:
+                file_id = message.document.file_id
+            elif message.video:
+                file_id = message.video.file_id
+            else:
+                raise TypeError("Message with this type can't be copied.")
+
+            media = utils.get_input_media_from_file_id(file_id=file_id)
+            multi_media.append(
+                raw.types.InputSingleMedia(
+                    media=media,
+                    random_id=self.rnd_id(),
+                    **await self.parser.parse(
+                        caption[i] if type(caption) is list and i < len(caption) and caption[i] is not None else
+                        caption if type(caption) is str and i == 0 else
+                        message.caption if message.caption and message.caption != "None" and not type(caption) is str else "")
+                )
+            )
+
+        r = await self.send(
+            raw.functions.messages.SendMultiMedia(
+                peer=await self.resolve_peer(chat_id),
+                multi_media=multi_media,
+                silent=disable_notification or None,
+                reply_to_msg_id=reply_to_message_id,
+                schedule_date=schedule_date
+            ),
+            sleep_threshold=60
+        )
+
+        return await utils.parse_messages(
+            self,
+            raw.types.messages.Messages(
+                messages=[m.message for m in filter(
+                    lambda u: isinstance(u, (raw.types.UpdateNewMessage,
+                                             raw.types.UpdateNewChannelMessage,
+                                             raw.types.UpdateNewScheduledMessage)),
+                    r.updates
+                )],
+                users=r.users,
+                chats=r.chats
+            )
+        )

--- a/pyrogram/methods/messages/copy_media_group.py
+++ b/pyrogram/methods/messages/copy_media_group.py
@@ -102,8 +102,8 @@ class CopyMediaGroup(Scaffold):
                     media=media,
                     random_id=self.rnd_id(),
                     **await self.parser.parse(
-                        captions[i] if type(captions) is list and i < len(captions) and captions[i] is not None else
-                        captions if type(captions) is str and i == 0 else
+                        captions[i] if isinstance(captions, list) and i < len(captions) and captions[i] else
+                        captions if isinstance(captions, str) and i == 0 else
                         message.caption if message.caption and message.caption != "None" and not type(captions) is str else "")
                 )
             )

--- a/pyrogram/methods/messages/copy_media_group.py
+++ b/pyrogram/methods/messages/copy_media_group.py
@@ -49,7 +49,7 @@ class CopyMediaGroup(Scaffold):
             message_id (``int``):
                 Message identifier in the chat specified in *from_chat_id*.
 
-            captions (``string`` or list of ``string`` , *optional*):
+            captions (``str`` | List of ``str`` , *optional*):
                 New caption for media, 0-1024 characters after entities parsing for each media.
                 If not specified, the original caption is kept.
                 Pass "" (empty string) to remove the caption.

--- a/pyrogram/methods/messages/copy_media_group.py
+++ b/pyrogram/methods/messages/copy_media_group.py
@@ -102,9 +102,9 @@ class CopyMediaGroup(Scaffold):
                     media=media,
                     random_id=self.rnd_id(),
                     **await self.parser.parse(
-                        caption[i] if type(caption) is list and i < len(caption) and caption[i] is not None else
-                        caption if type(caption) is str and i == 0 else
-                        message.caption if message.caption and message.caption != "None" and not type(caption) is str else "")
+                        captions[i] if type(captions) is list and i < len(captions) and captions[i] is not None else
+                        captions if type(captions) is str and i == 0 else
+                        message.caption if message.caption and message.caption != "None" and not type(captions) is str else "")
                 )
             )
 

--- a/pyrogram/methods/messages/copy_media_group.py
+++ b/pyrogram/methods/messages/copy_media_group.py
@@ -33,7 +33,7 @@ class CopyMediaGroup(Scaffold):
         reply_to_message_id: int = None,
         schedule_date: int = None,
     ) -> List["types.Message"]:
-        """Copy media group.
+        """Copy a media group by providing one of the message ids.
 
         Parameters:
             chat_id (``int`` | ``str``):
@@ -56,7 +56,7 @@ class CopyMediaGroup(Scaffold):
 
                 If a ``string`` is passed, it becomes a caption only for the first media.
                 If a list of ``string`` passed, each element becomes caption for each media element.
-                You can pass ``None`` in list to keep the original caption. Please check examples.
+                You can pass ``None`` in list to keep the original caption (see examples below).
 
             disable_notification (``bool``, *optional*):
                 Sends the message silently.
@@ -75,16 +75,15 @@ class CopyMediaGroup(Scaffold):
             .. code-block:: python
 
                 # Copy a media group
-                app.copy_media_group("me", "pyrogramlounge", 470061)
-                app.copy_media_group("me", "pyrogramlounge", 470061, captions="Single caption")
-                app.copy_media_group("me", "pyrogramlounge", 470061, captions=["Media 1 caption", None, ""])
+                app.copy_media_group("me", source_chat, message_id)
+                app.copy_media_group("me", source_chat, message_id, captions="single caption")
+                app.copy_media_group("me", source_chat, message_id, captions=["caption 1", None, ""])
         """
 
         media_group = await self.get_media_group(from_chat_id, message_id)
         multi_media = []
 
         for i, message in enumerate(media_group):
-
             if message.photo:
                 file_id = message.photo.file_id
             elif message.audio:

--- a/pyrogram/methods/messages/copy_media_group.py
+++ b/pyrogram/methods/messages/copy_media_group.py
@@ -93,7 +93,7 @@ class CopyMediaGroup(Scaffold):
             elif message.video:
                 file_id = message.video.file_id
             else:
-                raise TypeError("Message with this type can't be copied.")
+                raise ValueError("Message with this type can't be copied.")
 
             media = utils.get_input_media_from_file_id(file_id=file_id)
             multi_media.append(


### PR DESCRIPTION
A new method client.copy_media_group. 
You pass a chat_id and a single ``message_id``, and ``media_group`` that contains message with this ``message_id`` will be copied.

It was useful for me so I thought I could PR this.
I wanted to create it as flexible as possible, so attribute ``captions`` became a little mess inside, but IMO it's gonna be easy in use in exchange.

Big thanks for Legenda24 for helping me [(github](https://github.com/Legenda24), [Telegram ](https://t.me/legendax24))