### PR TITLE
Create new media type 'InputMediaCached' and update method 'SendMediaGroup''

### DIFF
--- a/pyrogram/methods/messages/send_media_group.py
+++ b/pyrogram/methods/messages/send_media_group.py
@@ -16,7 +16,6 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-import logging
 import os
 import re
 from typing import Union, List
@@ -27,8 +26,6 @@ from pyrogram import utils
 from pyrogram.file_id import FileType
 from pyrogram.scaffold import Scaffold
 
-log = logging.getLogger(__name__)
-
 
 class SendMediaGroup(Scaffold):
     # TODO: Add progress parameter
@@ -36,16 +33,17 @@ class SendMediaGroup(Scaffold):
         self,
         chat_id: Union[int, str],
         media: List[Union[
+            "types.InputMediaAudio",
             "types.InputMediaPhoto",
             "types.InputMediaVideo",
-            "types.InputMediaAudio",
-            "types.InputMediaDocument"
+            "types.InputMediaCached",
+            "types.InputMediaDocument",
         ]],
         disable_notification: bool = None,
         reply_to_message_id: int = None,
         schedule_date: int = None,
     ) -> List["types.Message"]:
-        """Send a group of photos or videos as an album.
+        """Send a group of media files as an album.
 
         Parameters:
             chat_id (``int`` | ``str``):
@@ -53,8 +51,8 @@ class SendMediaGroup(Scaffold):
                 For your personal cloud (Saved Messages) you can simply use "me" or "self".
                 For a contact that exists in your Telegram address book you can use his phone number (str).
 
-            media (List of :obj:`~pyrogram.types.InputMediaPhoto`, :obj:`~pyrogram.types.InputMediaVideo`, :obj:`~pyrogram.types.InputMediaAudio` and :obj:`~pyrogram.types.InputMediaDocument`):
-                A list describing photos and videos to be sent, must include 2–10 items.
+            media (List of :obj:`~pyrogram.types.InputMediaPhoto`, :obj:`~pyrogram.types.InputMediaVideo`, :obj:`~pyrogram.types.InputMediaAudio`, :obj:`~pyrogram.types.InputMediaCached` and :obj:`~pyrogram.types.InputMediaDocument`):
+                A list describing media files to be sent, must include 2–10 items.
 
             disable_notification (``bool``, *optional*):
                 Sends the message silently.
@@ -79,7 +77,8 @@ class SendMediaGroup(Scaffold):
                     [
                         InputMediaPhoto("photo1.jpg"),
                         InputMediaPhoto("photo2.jpg", caption="photo caption"),
-                        InputMediaVideo("video.mp4", caption="a video")
+                        InputMediaVideo("video.mp4", caption="a video"),
+                        InputMediaCached("AAMCAgADGQEAAQdw2mADFwuM", caption="is cached media")
                     ]
                 )
         """
@@ -218,6 +217,8 @@ class SendMediaGroup(Scaffold):
                     )
                 else:
                     media = utils.get_input_media_from_file_id(i.media, FileType.AUDIO)
+            elif isinstance(i, types.InputMediaCached):
+                media = utils.get_input_media_from_file_id(file_id=i.media)
             elif isinstance(i, types.InputMediaDocument):
                 if os.path.isfile(i.media):
                     media = await self.send(

--- a/pyrogram/types/input_media/__init__.py
+++ b/pyrogram/types/input_media/__init__.py
@@ -19,12 +19,13 @@
 from .input_media import InputMedia
 from .input_media_animation import InputMediaAnimation
 from .input_media_audio import InputMediaAudio
+from .input_media_cached import InputMediaCached
 from .input_media_document import InputMediaDocument
 from .input_media_photo import InputMediaPhoto
 from .input_media_video import InputMediaVideo
 from .input_phone_contact import InputPhoneContact
 
 __all__ = [
-    "InputMedia", "InputMediaAnimation", "InputMediaAudio", "InputMediaDocument", "InputMediaPhoto", "InputMediaVideo",
-    "InputPhoneContact"
+    "InputMedia", "InputMediaCached", "InputMediaAnimation", "InputMediaAudio", "InputMediaDocument",
+    "InputMediaPhoto", "InputMediaVideo", "InputPhoneContact"
 ]

--- a/pyrogram/types/input_media/input_media_cached.py
+++ b/pyrogram/types/input_media/input_media_cached.py
@@ -1,0 +1,55 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-2021 Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
+
+from typing import Optional, List
+
+from .input_media import InputMedia
+from ..messages_and_media import MessageEntity
+
+
+class InputMediaCached(InputMedia):
+    """A generic file to be sent inside an album.
+
+    Parameters:
+        media (``str``):
+            File to send.
+            Pass a file_id as string to send a file that exists on the Telegram servers.
+
+        caption (``str``, *optional*):
+            Caption of the document to be sent, 0-1024 characters.
+            If not specified, the original caption is kept. Pass "" (empty string) to remove the caption.
+
+        parse_mode (``str``, *optional*):
+            By default, texts are parsed using both Markdown and HTML styles.
+            You can combine both syntaxes together.
+            Pass "markdown" or "md" to enable Markdown-style parsing only.
+            Pass "html" to enable HTML-style parsing only.
+            Pass None to completely disable style parsing.
+
+        caption_entities (List of :obj:`~pyrogram.types.MessageEntity`):
+            List of special entities that appear in the caption, which can be specified instead of *parse_mode*.
+    """
+
+    def __init__(
+            self,
+            media: str,
+            caption: str = None,
+            parse_mode: Optional[str] = object,
+            caption_entities: List[MessageEntity] = None
+    ):
+        super().__init__(media, caption, parse_mode, caption_entities)


### PR DESCRIPTION
So I wanted to make a method to send groups of cached media. 

Then Legenda24 ([github](https://github.com/Legenda24), [Telegram](https://t.me/legendax24)) gave me a piece of advice that we can use types that already exists, but IMO it wasn't that convenient and easy so I decided to create a new type which could be 'created' from ``file_id`` and ``caption`` - ``InputMediaCached``.

I also adapted method ``SendMediaGroup`` for the changes.
Hope it'll be approved.