### PR TITLE
Fix to work with edit_message_caption works with reply_markup objects

### DIFF
--- a/pyrogram/types/bots_and_keyboards/callback_query.py
+++ b/pyrogram/types/bots_and_keyboards/callback_query.py
@@ -252,7 +252,7 @@ class CallbackQuery(Object, Update):
         Raises:
             RPCError: In case of a Telegram RPC error.
         """
-        return await self.edit_message_text(caption, parse_mode, reply_markup)
+        return await self.edit_message_text(caption, parse_mode, reply_markup=reply_markup)
 
     async def edit_message_media(
         self,


### PR DESCRIPTION
Since CallbackQuery.edit_message_text takes 4 arguments and CallbackQuery.edit_message_caption only 3, the reply_markup ends up to be the disable_web_page_preview one. Resolve this by specifying the argument name