### PR TITLE
added missing doc string for InputMedia types

### DIFF
--- a/pyrogram/types/input_media/input_media.py
+++ b/pyrogram/types/input_media/input_media.py
@@ -37,7 +37,7 @@ class InputMedia(Object):
     def __init__(
         self,
         media: str,
-        caption: str = None,
+        caption: str = "",
         parse_mode: str = None,
         caption_entities: List[MessageEntity] = None
     ):

--- a/pyrogram/types/input_media/input_media_animation.py
+++ b/pyrogram/types/input_media/input_media_animation.py
@@ -66,7 +66,7 @@ class InputMediaAnimation(InputMedia):
         self,
         media: str,
         thumb: str = None,
-        caption: str = None,
+        caption: str = "",
         parse_mode: Optional[str] = object,
         caption_entities: List[MessageEntity] = None,
         width: int = 0,

--- a/pyrogram/types/input_media/input_media_animation.py
+++ b/pyrogram/types/input_media/input_media_animation.py
@@ -29,7 +29,8 @@ class InputMediaAnimation(InputMedia):
         media (``str``):
             Animation to send.
             Pass a file_id as string to send a file that exists on the Telegram servers or
-            pass a file path as string to upload a new file that exists on your local machine.
+            pass a file path as string to upload a new file that exists on your local machine or
+            pass an HTTP URL as a string for Telegram to get an animation from the Internet.
 
         thumb (``str``, *optional*):
             Thumbnail of the animation file sent.

--- a/pyrogram/types/input_media/input_media_audio.py
+++ b/pyrogram/types/input_media/input_media_audio.py
@@ -68,7 +68,7 @@ class InputMediaAudio(InputMedia):
         self,
         media: str,
         thumb: str = None,
-        caption: str = None,
+        caption: str = "",
         parse_mode: Optional[str] = object,
         caption_entities: List[MessageEntity] = None,
         duration: int = 0,

--- a/pyrogram/types/input_media/input_media_audio.py
+++ b/pyrogram/types/input_media/input_media_audio.py
@@ -31,7 +31,8 @@ class InputMediaAudio(InputMedia):
         media (``str``):
             Audio to send.
             Pass a file_id as string to send an audio that exists on the Telegram servers or
-            pass a file path as string to upload a new audio that exists on your local machine.
+            pass a file path as string to upload a new audio that exists on your local machine or
+            pass an HTTP URL as a string for Telegram to get an audio file from the Internet.
 
         thumb (``str``, *optional*):
             Thumbnail of the music file album cover.

--- a/pyrogram/types/input_media/input_media_document.py
+++ b/pyrogram/types/input_media/input_media_document.py
@@ -57,7 +57,7 @@ class InputMediaDocument(InputMedia):
         self,
         media: str,
         thumb: str = None,
-        caption: str = None,
+        caption: str = "",
         parse_mode: Optional[str] = object,
         caption_entities: List[MessageEntity] = None
     ):

--- a/pyrogram/types/input_media/input_media_document.py
+++ b/pyrogram/types/input_media/input_media_document.py
@@ -29,7 +29,8 @@ class InputMediaDocument(InputMedia):
         media (``str``):
             File to send.
             Pass a file_id as string to send a file that exists on the Telegram servers or
-            pass a file path as string to upload a new file that exists on your local machine.
+            pass a file path as string to upload a new file that exists on your local machine or
+            pass an HTTP URL as a string for Telegram to get a file from the Internet.
 
         thumb (``str``):
             Thumbnail of the file sent.

--- a/pyrogram/types/input_media/input_media_photo.py
+++ b/pyrogram/types/input_media/input_media_photo.py
@@ -30,8 +30,8 @@ class InputMediaPhoto(InputMedia):
         media (``str``):
             Photo to send.
             Pass a file_id as string to send a photo that exists on the Telegram servers or
-            pass a file path as string to upload a new photo that exists on your local machine.
-            Sending photo by a URL is currently unsupported.
+            pass a file path as string to upload a new photo that exists on your local machine or
+            pass an HTTP URL as a string for Telegram to get a photo from the Internet.
 
         caption (``str``, *optional*):
             Caption of the photo to be sent, 0-1024 characters.

--- a/pyrogram/types/input_media/input_media_photo.py
+++ b/pyrogram/types/input_media/input_media_photo.py
@@ -51,7 +51,7 @@ class InputMediaPhoto(InputMedia):
     def __init__(
         self,
         media: str,
-        caption: str = None,
+        caption: str = "",
         parse_mode: Optional[str] = object,
         caption_entities: List[MessageEntity] = None
     ):

--- a/pyrogram/types/input_media/input_media_video.py
+++ b/pyrogram/types/input_media/input_media_video.py
@@ -70,7 +70,7 @@ class InputMediaVideo(InputMedia):
         self,
         media: str,
         thumb: str = None,
-        caption: str = None,
+        caption: str = "",
         parse_mode: Optional[str] = object,
         caption_entities: List[MessageEntity] = None,
         width: int = 0,

--- a/pyrogram/types/input_media/input_media_video.py
+++ b/pyrogram/types/input_media/input_media_video.py
@@ -30,8 +30,8 @@ class InputMediaVideo(InputMedia):
         media (``str``):
             Video to send.
             Pass a file_id as string to send a video that exists on the Telegram servers or
-            pass a file path as string to upload a new video that exists on your local machine.
-            Sending video by a URL is currently unsupported.
+            pass a file path as string to upload a new video that exists on your local machine or
+            pass an HTTP URL as a string for Telegram to get a video from the Internet.
 
         thumb (``str``):
             Thumbnail of the video sent.


### PR DESCRIPTION
Changes:
1. all media parameter supports "URL",  so  updated docs for the same.
2. changed default value of caption from None to "", as can be seen below.

![image](https://user-images.githubusercontent.com/62891774/107671911-59b9d580-6cba-11eb-94cb-10800118ea00.png)
