### PR TITLE
ignore null buttons in reply_markup.write()

### DIFF
--- a/pyrogram/types/bots_and_keyboards/inline_keyboard_markup.py
+++ b/pyrogram/types/bots_and_keyboards/inline_keyboard_markup.py
@@ -55,6 +55,6 @@ class InlineKeyboardMarkup(Object):
     def write(self):
         return raw.types.ReplyInlineMarkup(
             rows=[raw.types.KeyboardButtonRow(
-                buttons=[j.write() for j in i]
+                buttons=[j.write() for j in i if j]
             ) for i in self.inline_keyboard]
         )


### PR DESCRIPTION
this change is fixing a problem with building keyboard when the button is null
its happens when trying to copy message with unsupported button (login button) which is null 
https://t.me/pyrogramchat/291847 - my question about it