### PR TITLE
Fixed documentation

### DIFF
--- a/pyrogram/filters.py
+++ b/pyrogram/filters.py
@@ -127,12 +127,12 @@ def create(func: Callable, name: str = None, **kwargs) -> Filter:
 
     Parameters:
         func (``callable``):
-            A function that accepts two positional arguments *(filter, update)* and returns a boolean: True if the
-            update should be handled, False otherwise. The *filter* argument refers to the filter itself and can be used
-            to access keyword arguments (read below). The *update* argument type will vary depending on which
-            `Handler <handlers>`_ is coming from. For example, in a :obj:`~pyrogram.handlers.MessageHandler` the
-            *update* argument will be a :obj:`~pyrogram.types.Message`; in a
-            :obj:`~pyrogram.handlers.CallbackQueryHandler` the *update* will be a :obj:`~pyrogram.types.CallbackQuery`.
+            A function that accepts three positional arguments *(filter, client, update)* and returns a boolean: True if the
+            update should be handled, False otherwise. 
+            The *filter* argument refers to the filter itself and can be used to access keyword arguments (read below). 
+            The *client* argument refers to the :obj:`~pyrogram.Client` that received the update.
+            The *update* argument type will vary depending on which `Handler <handlers>`_ is coming from. 
+            For example, in a :obj:`~pyrogram.handlers.MessageHandler` the *update* argument will be a :obj:`~pyrogram.types.Message`; in a :obj:`~pyrogram.handlers.CallbackQueryHandler` the *update* will be a :obj:`~pyrogram.types.CallbackQuery`.
             Your function body can then access the incoming update attributes and decide whether to allow it or not.
 
         name (``str``, *optional*):


### PR DESCRIPTION
Wrong documentation for filters.create, callable funcitions requires 3 positional arguments (filter, client, update) and not two.