### PR TITLE
Missing info in forward_from_chat

### DIFF
--- a/pyrogram/types/messages_and_media/message.py
+++ b/pyrogram/types/messages_and_media/message.py
@@ -84,7 +84,7 @@ class Message(Object, Update):
             For messages forwarded from users who have hidden their accounts, name of the user.
 
         forward_from_chat (:obj:`~pyrogram.types.Chat`, *optional*):
-            For messages forwarded from channels, information about the original channel.
+            For messages forwarded from channels, information about the original channel. For messages forwarded from anonymous group administrators, information about the original supergroup.
 
         forward_from_message_id (``int``, *optional*):
             For messages forwarded from channels, identifier of the original message in the channel.


### PR DESCRIPTION
Added info regarding supergroup in forward_from_chat