### PR TITLE
Fix GameHighScore in the chat with yourself

### DIFF
--- a/pyrogram/types/bots_and_keyboards/game_high_score.py
+++ b/pyrogram/types/bots_and_keyboards/game_high_score.py
@@ -64,7 +64,7 @@ class GameHighScore(Object):
     @staticmethod
     def _parse_action(client, service: raw.types.MessageService, users: dict):
         return GameHighScore(
-            user=types.User._parse(client, users[utils.get_raw_peer_id(service.from_id)]),
+            user=types.User._parse(client, users[utils.get_raw_peer_id(service.from_id or service.peer_id)]),
             score=service.action.score,
             client=client
         )


### PR DESCRIPTION
Since `service.from_id` is None (chat with yourself), `utils.get_raw_peer_id` throws an error.