### PR TITLE
Small improvements for handlers and filters

### DIFF
--- a/pyrogram/filters.py
+++ b/pyrogram/filters.py
@@ -128,10 +128,10 @@ def create(func: Callable, name: str = None, **kwargs) -> Filter:
     Parameters:
         func (``callable``):
             A function that accepts three positional arguments *(filter, client, update)* and returns a boolean: True if the
-            update should be handled, False otherwise. 
-            The *filter* argument refers to the filter itself and can be used to access keyword arguments (read below). 
+            update should be handled, False otherwise.
+            The *filter* argument refers to the filter itself and can be used to access keyword arguments (read below).
             The *client* argument refers to the :obj:`~pyrogram.Client` that received the update.
-            The *update* argument type will vary depending on which `Handler <handlers>`_ is coming from. 
+            The *update* argument type will vary depending on which `Handler <handlers>`_ is coming from.
             For example, in a :obj:`~pyrogram.handlers.MessageHandler` the *update* argument will be a :obj:`~pyrogram.types.Message`; in a :obj:`~pyrogram.handlers.CallbackQueryHandler` the *update* will be a :obj:`~pyrogram.types.CallbackQuery`.
             Your function body can then access the incoming update attributes and decide whether to allow it or not.
 


### PR DESCRIPTION
These changes allow passing kwargs to handlers from filters.
Here is an example of how this can be used:
```python
import re
from pyrogram import filters, Client

client = Client(...)

def regex_filter(pattern):
    def check(flt, client, message):
        match = re.match(flt.pattern, message.text)
        if match:
            return {"text": match.group(1)}

    return filters.create(
        check,
        "RegexFilter",
        pattern=pattern,
    )


@client.on_message(regex_filter(r"/say (.*)"))
def handler(client, message, text):
    message.reply(text)


client.run()
```
![image](https://user-images.githubusercontent.com/26704473/116649802-bc9d3d80-a988-11eb-99e2-cd839a8c3c1e.png)
