### PR TITLE
Change variable name to avoid conflts with Telegram TL schema

### DIFF
--- a/compiler/api/compiler.py
+++ b/compiler/api/compiler.py
@@ -420,7 +420,7 @@ def start(format: bool = False):
                 ])
 
                 write_types += write_flags
-                read_types += "flags = Int.read(data)\n        "
+                read_types += "flags = Int.read(data_)\n        "
 
                 continue
 
@@ -436,7 +436,7 @@ def start(format: bool = False):
                     write_types += f"data.write({flag_type.title()}(self.{arg_name}))\n        "
 
                     read_types += "\n        "
-                    read_types += f"{arg_name} = {flag_type.title()}.read(data) if flags & (1 << {index}) else None"
+                    read_types += f"{arg_name} = {flag_type.title()}.read(data_) if flags & (1 << {index}) else None"
                 elif "vector" in flag_type.lower():
                     sub_type = arg_type.split("<")[1][:-1]
 
@@ -447,7 +447,7 @@ def start(format: bool = False):
                     )
 
                     read_types += "\n        "
-                    read_types += "{} = TLObject.read(data{}) if flags & (1 << {}) else []\n        ".format(
+                    read_types += "{} = TLObject.read(data_{}) if flags & (1 << {}) else []\n        ".format(
                         arg_name, f", {sub_type.title()}" if sub_type in CORE_TYPES else "", index
                     )
                 else:
@@ -456,14 +456,14 @@ def start(format: bool = False):
                     write_types += f"data.write(self.{arg_name}.write())\n        "
 
                     read_types += "\n        "
-                    read_types += f"{arg_name} = TLObject.read(data) if flags & (1 << {index}) else None\n        "
+                    read_types += f"{arg_name} = TLObject.read(data_) if flags & (1 << {index}) else None\n        "
             else:
                 if arg_type in CORE_TYPES:
                     write_types += "\n        "
                     write_types += f"data.write({arg_type.title()}(self.{arg_name}))\n        "
 
                     read_types += "\n        "
-                    read_types += f"{arg_name} = {arg_type.title()}.read(data)\n        "
+                    read_types += f"{arg_name} = {arg_type.title()}.read(data_)\n        "
                 elif "vector" in arg_type.lower():
                     sub_type = arg_type.split("<")[1][:-1]
 
@@ -473,7 +473,7 @@ def start(format: bool = False):
                     )
 
                     read_types += "\n        "
-                    read_types += "{} = TLObject.read(data{})\n        ".format(
+                    read_types += "{} = TLObject.read(data_{})\n        ".format(
                         arg_name, f", {sub_type.title()}" if sub_type in CORE_TYPES else ""
                     )
                 else:
@@ -481,7 +481,7 @@ def start(format: bool = False):
                     write_types += f"data.write(self.{arg_name}.write())\n        "
 
                     read_types += "\n        "
-                    read_types += f"{arg_name} = TLObject.read(data)\n        "
+                    read_types += f"{arg_name} = TLObject.read(data_)\n        "
 
         slots = ", ".join([f'"{i[0]}"' for i in sorted_args])
         return_arguments = ", ".join([f"{i[0]}={i[0]}" for i in sorted_args])

--- a/compiler/api/compiler.py
+++ b/compiler/api/compiler.py
@@ -416,11 +416,11 @@ def start(format: bool = False):
                 write_flags = "\n        ".join([
                     "flags = 0",
                     "\n        ".join(write_flags),
-                    "data.write(Int(flags))\n        "
+                    "b.write(Int(flags))\n        "
                 ])
 
                 write_types += write_flags
-                read_types += "flags = Int.read(data_)\n        "
+                read_types += "flags = Int.read(b)\n        "
 
                 continue
 
@@ -433,55 +433,55 @@ def start(format: bool = False):
                 elif flag_type in CORE_TYPES:
                     write_types += "\n        "
                     write_types += f"if self.{arg_name} is not None:\n            "
-                    write_types += f"data.write({flag_type.title()}(self.{arg_name}))\n        "
+                    write_types += f"b.write({flag_type.title()}(self.{arg_name}))\n        "
 
                     read_types += "\n        "
-                    read_types += f"{arg_name} = {flag_type.title()}.read(data_) if flags & (1 << {index}) else None"
+                    read_types += f"{arg_name} = {flag_type.title()}.read(b) if flags & (1 << {index}) else None"
                 elif "vector" in flag_type.lower():
                     sub_type = arg_type.split("<")[1][:-1]
 
                     write_types += "\n        "
                     write_types += f"if self.{arg_name} is not None:\n            "
-                    write_types += "data.write(Vector(self.{}{}))\n        ".format(
+                    write_types += "b.write(Vector(self.{}{}))\n        ".format(
                         arg_name, f", {sub_type.title()}" if sub_type in CORE_TYPES else ""
                     )
 
                     read_types += "\n        "
-                    read_types += "{} = TLObject.read(data_{}) if flags & (1 << {}) else []\n        ".format(
+                    read_types += "{} = TLObject.read(b{}) if flags & (1 << {}) else []\n        ".format(
                         arg_name, f", {sub_type.title()}" if sub_type in CORE_TYPES else "", index
                     )
                 else:
                     write_types += "\n        "
                     write_types += f"if self.{arg_name} is not None:\n            "
-                    write_types += f"data.write(self.{arg_name}.write())\n        "
+                    write_types += f"b.write(self.{arg_name}.write())\n        "
 
                     read_types += "\n        "
-                    read_types += f"{arg_name} = TLObject.read(data_) if flags & (1 << {index}) else None\n        "
+                    read_types += f"{arg_name} = TLObject.read(b) if flags & (1 << {index}) else None\n        "
             else:
                 if arg_type in CORE_TYPES:
                     write_types += "\n        "
-                    write_types += f"data.write({arg_type.title()}(self.{arg_name}))\n        "
+                    write_types += f"b.write({arg_type.title()}(self.{arg_name}))\n        "
 
                     read_types += "\n        "
-                    read_types += f"{arg_name} = {arg_type.title()}.read(data_)\n        "
+                    read_types += f"{arg_name} = {arg_type.title()}.read(b)\n        "
                 elif "vector" in arg_type.lower():
                     sub_type = arg_type.split("<")[1][:-1]
 
                     write_types += "\n        "
-                    write_types += "data.write(Vector(self.{}{}))\n        ".format(
+                    write_types += "b.write(Vector(self.{}{}))\n        ".format(
                         arg_name, f", {sub_type.title()}" if sub_type in CORE_TYPES else ""
                     )
 
                     read_types += "\n        "
-                    read_types += "{} = TLObject.read(data_{})\n        ".format(
+                    read_types += "{} = TLObject.read(b{})\n        ".format(
                         arg_name, f", {sub_type.title()}" if sub_type in CORE_TYPES else ""
                     )
                 else:
                     write_types += "\n        "
-                    write_types += f"data.write(self.{arg_name}.write())\n        "
+                    write_types += f"b.write(self.{arg_name}.write())\n        "
 
                     read_types += "\n        "
-                    read_types += f"{arg_name} = TLObject.read(data_)\n        "
+                    read_types += f"{arg_name} = TLObject.read(b)\n        "
 
         slots = ", ".join([f'"{i[0]}"' for i in sorted_args])
         return_arguments = ", ".join([f"{i[0]}={i[0]}" for i in sorted_args])

--- a/compiler/api/template/combinator.txt
+++ b/compiler/api/template/combinator.txt
@@ -23,7 +23,7 @@ class {name}(TLObject):  # type: ignore
         {fields}
 
     @staticmethod
-    def read(data: BytesIO, *args: Any) -> "{name}":
+    def read(data_: BytesIO, *args: Any) -> "{name}":
         {read_types}
         return {name}({return_arguments})
 

--- a/compiler/api/template/combinator.txt
+++ b/compiler/api/template/combinator.txt
@@ -23,13 +23,13 @@ class {name}(TLObject):  # type: ignore
         {fields}
 
     @staticmethod
-    def read(data_: BytesIO, *args: Any) -> "{name}":
+    def read(b: BytesIO, *args: Any) -> "{name}":
         {read_types}
         return {name}({return_arguments})
 
     def write(self) -> bytes:
-        data = BytesIO()
-        data.write(Int(self.ID, False))
+        b = BytesIO()
+        b.write(Int(self.ID, False))
 
         {write_types}
-        return data.getvalue()
+        return b.getvalue()

--- a/pyrogram/raw/core/tl_object.py
+++ b/pyrogram/raw/core/tl_object.py
@@ -29,8 +29,8 @@ class TLObject:
     QUALNAME = "Base"
 
     @classmethod
-    def read(cls, data: BytesIO, *args: Any) -> Any:
-        return cast(TLObject, objects[int.from_bytes(data.read(4), "little")]).read(data, *args)
+    def read(cls, b: BytesIO, *args: Any) -> Any:
+        return cast(TLObject, objects[int.from_bytes(b.read(4), "little")]).read(b, *args)
 
     def write(self, *args: Any) -> bytes:
         pass

--- a/pyrogram/types/bots_and_keyboards/callback_query.py
+++ b/pyrogram/types/bots_and_keyboards/callback_query.py
@@ -110,7 +110,7 @@ class CallbackQuery(Object, Update):
         # ignoring/replacing errors, this way, button clicks will still work.
         try:
             data = callback_query.data.decode()
-        except UnicodeDecodeError:
+        except (UnicodeDecodeError, AttributeError):
             data = callback_query.data
 
         return CallbackQuery(


### PR DESCRIPTION
Currently, the api compiler is using `data` as its function argument.  

However, [updateBotCallbackQuery](https://core.telegram.org/constructor/updateBotCallbackQuery) is use the same word `data` as its argument.  
It will cause the problem when the bot gets the callback query with no data (Like the game button).

Trying to fix issue #608 and make game button usable.