### PR TITLE
Add update handlers for connected, disconnected and ready

### DIFF
--- a/docs/source/api/decorators.rst
+++ b/docs/source/api/decorators.rst
@@ -49,7 +49,7 @@ Index
     - :meth:`~Client.on_poll`
     - :meth:`~Client.on_connect`
     - :meth:`~Client.on_disconnect`
-    - :meth:`~Client.on_client_ready`
+    - :meth:`~Client.on_ready`
     - :meth:`~Client.on_raw_update`
 
 -----
@@ -68,5 +68,5 @@ Details
 .. autodecorator:: pyrogram.Client.on_poll()
 .. autodecorator:: pyrogram.Client.on_connect()
 .. autodecorator:: pyrogram.Client.on_disconnect()
-.. autodecorator:: pyrogram.Client.on_client_ready()
+.. autodecorator:: pyrogram.Client.on_ready()
 .. autodecorator:: pyrogram.Client.on_raw_update()

--- a/docs/source/api/decorators.rst
+++ b/docs/source/api/decorators.rst
@@ -47,7 +47,9 @@ Index
     - :meth:`~Client.on_deleted_messages`
     - :meth:`~Client.on_user_status`
     - :meth:`~Client.on_poll`
+    - :meth:`~Client.on_connect`
     - :meth:`~Client.on_disconnect`
+    - :meth:`~Client.on_client_ready`
     - :meth:`~Client.on_raw_update`
 
 -----
@@ -64,5 +66,7 @@ Details
 .. autodecorator:: pyrogram.Client.on_deleted_messages()
 .. autodecorator:: pyrogram.Client.on_user_status()
 .. autodecorator:: pyrogram.Client.on_poll()
+.. autodecorator:: pyrogram.Client.on_connect()
 .. autodecorator:: pyrogram.Client.on_disconnect()
+.. autodecorator:: pyrogram.Client.on_client_ready()
 .. autodecorator:: pyrogram.Client.on_raw_update()

--- a/docs/source/api/handlers.rst
+++ b/docs/source/api/handlers.rst
@@ -44,7 +44,9 @@ Index
     - :class:`ChatMemberUpdatedHandler`
     - :class:`UserStatusHandler`
     - :class:`PollHandler`
+    - :class:`ConnectHandler`
     - :class:`DisconnectHandler`
+    - :class:`ClientReadyHandler`
     - :class:`RawUpdateHandler`
 
 -----
@@ -61,5 +63,7 @@ Details
 .. autoclass:: ChatMemberUpdatedHandler()
 .. autoclass:: UserStatusHandler()
 .. autoclass:: PollHandler()
+.. autoclass:: ConnectHandler()
 .. autoclass:: DisconnectHandler()
+.. autoclass:: ClientReadyHandler()
 .. autoclass:: RawUpdateHandler()

--- a/pyrogram/dispatcher.py
+++ b/pyrogram/dispatcher.py
@@ -127,8 +127,8 @@ class Dispatcher:
             (UpdateMessagePoll,): poll_parser,
             (UpdateBotInlineSend,): chosen_inline_result_parser,
             Dispatcher.CHAT_MEMBER_UPDATES: chat_member_updated_parser,
-            UpdateNetworkStatus: connection_status_parser,
-            UpdateClientReady: client_ready_parser,
+            (UpdateNetworkStatus,): connection_status_parser,
+            (UpdateClientReady,): client_ready_parser,
         }
 
         self.update_parsers = {key: value for key_tuple, value in self.update_parsers.items() for key in key_tuple}

--- a/pyrogram/dispatcher.py
+++ b/pyrogram/dispatcher.py
@@ -19,6 +19,7 @@
 import asyncio
 import inspect
 import logging
+from collections.abc import Iterable
 from collections import OrderedDict
 
 import pyrogram
@@ -112,11 +113,11 @@ class Dispatcher:
 
         async def connection_status_parser(update:UpdateNetworkStatus, users, chats):
             if update.connected:
-                return None, ConnectHandler
-            return None, DisconnectHandler
+                return (), ConnectHandler
+            return (), DisconnectHandler
 
         async def client_ready_parser(update:UpdateClientReady, user, chats):
-            return None, ClientReadyHandler
+            return (), ClientReadyHandler
 
         self.update_parsers = {
             Dispatcher.MESSAGE_UPDATES: message_parser,
@@ -215,7 +216,9 @@ class Dispatcher:
                             if isinstance(handler, handler_type):
                                 try:
                                     if await handler.check(self.client, parsed_update):
-                                        args = (parsed_update,)
+                                        args = parsed_update
+                                        if not isinstance(args, Iterable):
+                                            args = (args,)
                                 except Exception as e:
                                     log.error(e, exc_info=True)
                                     continue

--- a/pyrogram/handlers/__init__.py
+++ b/pyrogram/handlers/__init__.py
@@ -21,6 +21,8 @@ from .chat_member_updated_handler import ChatMemberUpdatedHandler
 from .chosen_inline_result_handler import ChosenInlineResultHandler
 from .deleted_messages_handler import DeletedMessagesHandler
 from .disconnect_handler import DisconnectHandler
+from .connect_handler import ConnectHandler
+from .client_ready_handler import ClientReadyHandler
 from .inline_query_handler import InlineQueryHandler
 from .message_handler import MessageHandler
 from .poll_handler import PollHandler

--- a/pyrogram/handlers/client_ready_handler.py
+++ b/pyrogram/handlers/client_ready_handler.py
@@ -1,0 +1,41 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-2021 Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
+
+from .handler import Handler
+
+
+class ClientReadyHandler(Handler):
+    """The ClientReady handler class. Used to handle client signaling itself ready. It is intended to be used with
+    :meth:`~pyrogram.Client.add_handler`
+
+    For a nicer way to register this handler, have a look at the
+    :meth:`~pyrogram.Client.on_client_ready` decorator.
+
+    Parameters:
+        callback (``callable``):
+            Pass a function that will be called when a connection occurs. It takes *(client)*
+            as positional argument (look at the section below for a detailed description).
+
+    Other parameters:
+        client (:obj:`~pyrogram.Client`):
+            The Client itself. Useful, for example, when you want to change the proxy before a new connection
+            is established.
+    """
+
+    def __init__(self, callback: callable):
+        super().__init__(callback)

--- a/pyrogram/handlers/connect_handler.py
+++ b/pyrogram/handlers/connect_handler.py
@@ -1,0 +1,41 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-2021 Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
+
+from .handler import Handler
+
+
+class ConnectHandler(Handler):
+    """The Connect handler class. Used to handle connections. It is intended to be used with
+    :meth:`~pyrogram.Client.add_handler`
+
+    For a nicer way to register this handler, have a look at the
+    :meth:`~pyrogram.Client.on_connect` decorator.
+
+    Parameters:
+        callback (``callable``):
+            Pass a function that will be called when a connection occurs. It takes *(client)*
+            as positional argument (look at the section below for a detailed description).
+
+    Other parameters:
+        client (:obj:`~pyrogram.Client`):
+            The Client itself. Useful, for example, when you want to change the proxy before a new connection
+            is established.
+    """
+
+    def __init__(self, callback: callable):
+        super().__init__(callback)

--- a/pyrogram/methods/decorators/__init__.py
+++ b/pyrogram/methods/decorators/__init__.py
@@ -22,7 +22,7 @@ from .on_chosen_inline_result import OnChosenInlineResult
 from .on_deleted_messages import OnDeletedMessages
 from .on_disconnect import OnDisconnect
 from .on_connect import OnConnect
-from .on_client_ready import OnClientReady
+from .on_ready import OnReady
 from .on_inline_query import OnInlineQuery
 from .on_message import OnMessage
 from .on_poll import OnPoll
@@ -37,7 +37,7 @@ class Decorators(
     OnRawUpdate,
     OnDisconnect,
     OnConnect,
-    OnClientReady,
+    OnReady,
     OnUserStatus,
     OnInlineQuery,
     OnPoll,

--- a/pyrogram/methods/decorators/__init__.py
+++ b/pyrogram/methods/decorators/__init__.py
@@ -21,6 +21,8 @@ from .on_chat_member_updated import OnChatMemberUpdated
 from .on_chosen_inline_result import OnChosenInlineResult
 from .on_deleted_messages import OnDeletedMessages
 from .on_disconnect import OnDisconnect
+from .on_connect import OnConnect
+from .on_client_ready import OnClientReady
 from .on_inline_query import OnInlineQuery
 from .on_message import OnMessage
 from .on_poll import OnPoll
@@ -34,6 +36,8 @@ class Decorators(
     OnCallbackQuery,
     OnRawUpdate,
     OnDisconnect,
+    OnConnect,
+    OnClientReady,
     OnUserStatus,
     OnInlineQuery,
     OnPoll,

--- a/pyrogram/methods/decorators/on_client_ready.py
+++ b/pyrogram/methods/decorators/on_client_ready.py
@@ -23,12 +23,12 @@ from pyrogram.filters import Filter
 from pyrogram.scaffold import Scaffold
 
 
-class OnDisconnect(Scaffold):
-    def on_disconnect(self=None, group: int = 0) -> callable:
-        """Decorator for handling disconnections.
+class OnClientReady(Scaffold):
+    def on_client_ready(self=None, group: int = 0) -> callable:
+        """Decorator for handling client signaling itself ready.
 
         This does the same thing as :meth:`~pyrogram.Client.add_handler` using the
-        :obj:`~pyrogram.handlers.DisconnectHandler`.
+        :obj:`~pyrogram.handlers.ClientReadyHandler`.
 
         Parameters:
             group (``int``, *optional*):
@@ -37,14 +37,14 @@ class OnDisconnect(Scaffold):
 
         def decorator(func: Callable) -> Callable:
             if isinstance(self, pyrogram.Client):
-                self.add_handler(pyrogram.handlers.DisconnectHandler(func), group)
+                self.add_handler(pyrogram.handlers.ClientReadyHandler(func), group)
             elif isinstance(self, Filter) or self is None:
                 if not hasattr(func, "handlers"):
                     func.handlers = []
 
                 func.handlers.append(
                     (
-                        pyrogram.handlers.DisconnectHandler(func), group
+                        pyrogram.handlers.ClientReadyHandler(func), group
                     )
                 )
 

--- a/pyrogram/methods/decorators/on_connect.py
+++ b/pyrogram/methods/decorators/on_connect.py
@@ -23,12 +23,12 @@ from pyrogram.filters import Filter
 from pyrogram.scaffold import Scaffold
 
 
-class OnDisconnect(Scaffold):
-    def on_disconnect(self=None, group: int = 0) -> callable:
-        """Decorator for handling disconnections.
+class OnConnect(Scaffold):
+    def on_connect(self=None, group: int = 0) -> callable:
+        """Decorator for handling connections.
 
         This does the same thing as :meth:`~pyrogram.Client.add_handler` using the
-        :obj:`~pyrogram.handlers.DisconnectHandler`.
+        :obj:`~pyrogram.handlers.ConnectHandler`.
 
         Parameters:
             group (``int``, *optional*):
@@ -37,14 +37,14 @@ class OnDisconnect(Scaffold):
 
         def decorator(func: Callable) -> Callable:
             if isinstance(self, pyrogram.Client):
-                self.add_handler(pyrogram.handlers.DisconnectHandler(func), group)
+                self.add_handler(pyrogram.handlers.ConnectHandler(func), group)
             elif isinstance(self, Filter) or self is None:
                 if not hasattr(func, "handlers"):
                     func.handlers = []
 
                 func.handlers.append(
                     (
-                        pyrogram.handlers.DisconnectHandler(func), group
+                        pyrogram.handlers.ConnectHandler(func), group
                     )
                 )
 

--- a/pyrogram/methods/decorators/on_ready.py
+++ b/pyrogram/methods/decorators/on_ready.py
@@ -23,8 +23,8 @@ from pyrogram.filters import Filter
 from pyrogram.scaffold import Scaffold
 
 
-class OnClientReady(Scaffold):
-    def on_client_ready(self=None, group: int = 0) -> callable:
+class OnReady(Scaffold):
+    def on_ready(self=None, group: int = 0) -> callable:
         """Decorator for handling client signaling itself ready.
 
         This does the same thing as :meth:`~pyrogram.Client.add_handler` using the

--- a/pyrogram/methods/utilities/add_handler.py
+++ b/pyrogram/methods/utilities/add_handler.py
@@ -16,7 +16,6 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from pyrogram.handlers import DisconnectHandler
 from pyrogram.handlers.handler import Handler
 from pyrogram.scaffold import Scaffold
 
@@ -56,9 +55,6 @@ class AddHandler(Scaffold):
 
                 app.run()
         """
-        if isinstance(handler, DisconnectHandler):
-            self.disconnect_handler = handler.callback
-        else:
-            self.dispatcher.add_handler(handler, group)
+        self.dispatcher.add_handler(handler, group)
 
         return handler, group

--- a/pyrogram/methods/utilities/remove_handler.py
+++ b/pyrogram/methods/utilities/remove_handler.py
@@ -16,7 +16,6 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from pyrogram.handlers import DisconnectHandler
 from pyrogram.handlers.handler import Handler
 from pyrogram.scaffold import Scaffold
 
@@ -54,7 +53,4 @@ class RemoveHandler(Scaffold):
 
                 app.run()
         """
-        if isinstance(handler, DisconnectHandler):
-            self.disconnect_handler = None
-        else:
-            self.dispatcher.remove_handler(handler, group)
+        self.dispatcher.remove_handler(handler, group)

--- a/pyrogram/methods/utilities/start.py
+++ b/pyrogram/methods/utilities/start.py
@@ -20,6 +20,7 @@ import logging
 
 from pyrogram import raw
 from pyrogram.scaffold import Scaffold
+from pyrogram.session.session import UpdateClientReady
 
 log = logging.getLogger(__name__)
 
@@ -66,4 +67,5 @@ class Start(Scaffold):
             raise
         else:
             await self.initialize()
+            self.dispatcher.updates_queue.put_nowait((UpdateClientReady(), None, None))
             return self

--- a/pyrogram/methods/utilities/stop.py
+++ b/pyrogram/methods/utilities/stop.py
@@ -17,6 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 from pyrogram.scaffold import Scaffold
+from pyrogram.session.session import UpdateNetworkStatus
 
 
 class Stop(Scaffold):

--- a/pyrogram/scaffold.py
+++ b/pyrogram/scaffold.py
@@ -105,8 +105,6 @@ class Scaffold:
 
         self.dispatcher = None
 
-        self.disconnect_handler = None
-
         self.loop = None
 
     async def send(self, *args, **kwargs):


### PR DESCRIPTION
Added
`@Client.on_ready()`
`@Client.on_connect()`
`@Client.on_disconnect()`
decorators (and related Handlers)

These events can be registered from smart plugins and can be grouped (unlike how `DisconnectHandler` was implemented).
To achieve this, "fake" updates are pushed on dispatcher's `updates_queue`. These are special "sentinel" classes defined in `pyrogram.session.session.py` and hold almost no information.

I had to map these handlers in the dispatcher. Also, the dispatcher used to just make a tuple of `parsed_update` (the object given out by the update parser). Since these updates hold no information to parse, they don't need any other argument in the callback other than `client`. To allow this, now `parsed_update` is checked, and if not iterable, a tuple is made. Like this, parsers can return iterables with multiple args (or none).

I'm not sure how docs are generated? I added the new methods and object inside the proper `.rst` files.