### PR TITLE
Removed create_task

### DIFF
--- a/pyrogram/methods/advanced/save_file.py
+++ b/pyrogram/methods/advanced/save_file.py
@@ -103,7 +103,7 @@ class SaveFile(Scaffold):
                     return
 
                 try:
-                    await self.loop.create_task(session.send(data))
+                    await session.send(data)
                 except Exception as e:
                     log.error(e)
 


### PR DESCRIPTION
No need to use loop.create_task in workers, because we awaiting immediately