### PR TITLE
Fix Attribute error when recieved ChatForbidden

### DIFF
--- a/pyrogram/types/user_and_chats/chat.py
+++ b/pyrogram/types/user_and_chats/chat.py
@@ -309,7 +309,7 @@ class Chat(Object):
 
     @staticmethod
     def _parse_chat(client, chat: Union[raw.types.Chat, raw.types.User, raw.types.Channel]) -> "Chat":
-        if isinstance(chat, raw.types.Chat):
+        if isinstance(chat, (raw.types.Chat, raw.types.ChatForbidden)):
             return Chat._parse_chat_chat(client, chat)
         elif isinstance(chat, raw.types.User):
             return Chat._parse_user_chat(client, chat)


### PR DESCRIPTION
There were a random exception raised when client kicked from a private group.
Turns out that the recieved type was a `raw.types.ChatForbidden` not a `raw.types.Chat`.
Causing `_parse_chat()` calling `_parse_channel_chat()`.


```
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/pyrogram/dispatcher.py", line 191, in handler_worker
    await parser(update, users, chats)
  File "/usr/local/lib/python3.9/site-packages/pyrogram/dispatcher.py", line 107, in chat_member_updated_parser
    return pyrogram.types.ChatMemberUpdated._parse(self.client, update, users, chats), ChatMemberUpdatedHandler
  File "/usr/local/lib/python3.9/site-packages/pyrogram/types/user_and_chats/chat_member_updated.py", line 94, in _parse
    chat=types.Chat._parse_chat(client, chats[chat_id]),
  File "/usr/local/lib/python3.9/site-packages/pyrogram/types/user_and_chats/chat.py", line 317, in _parse_chat
    return Chat._parse_channel_chat(client, chat)
  File "/usr/local/lib/python3.9/site-packages/pyrogram/types/user_and_chats/chat.py", line 224, in _parse_channel_chat
    type="supergroup" if channel.megagroup else "channel",
AttributeError: 'ChatForbidden' object has no attribute 'megagroup'
```