### PR TITLE
Recover gaps

### DIFF
--- a/pyrogram/client.py
+++ b/pyrogram/client.py
@@ -590,37 +590,56 @@ class Client(Methods, Scaffold):
                     self.dispatcher.updates_queue.put_nowait((diff.other_updates[0], {}, {}))
         elif isinstance(updates, raw.types.updates.State):
             local_pts = await self.storage.pts()
+            date = await self.storage.date()
 
             if local_pts >= updates.pts:
                 return
 
-            diff = await self.send(
-                raw.functions.updates.GetDifference(
-                    pts=local_pts,
-                    date=await self.storage.date(),
-                    qts=-1
+            while True:
+                diff = await self.send(
+                    raw.functions.updates.GetDifference(
+                        pts=local_pts,
+                        date=date,
+                        qts=-1
+                    )
                 )
-            )
 
-            users = {u.id: u for u in diff.users}
-            chats = {c.id: c for c in diff.chats}
+                if isinstance(diff, raw.types.updates.DifferenceEmpty):
+                    await self.storage.seq(diff.seq)
+                    await self.storage.date(diff.date)
+                    break
+                elif isinstance(diff, raw.types.updates.DifferenceTooLong):
+                    await self.storage.pts(diff.pts)
+                    log.info(diff)
+                    continue
 
-            for msg in diff.new_messages:
-                self.dispatcher.updates_queue.put_nowait((
-                    raw.types.UpdateNewMessage(
-                        message=msg,
-                        pts=diff.state.pts,
-                        pts_count=-1
-                    ),
-                    users,
-                    chats
-                ))
+                # Difference or DifferenceSlice
 
-            for update in diff.other_updates:
-                self.dispatcher.updates_queue.put_nowait((update, users, chats))
+                users = {u.id: u for u in diff.users}
+                chats = {c.id: c for c in diff.chats}
+                state = getattr(diff, "state", None) or getattr(diff, "intermediate_state", None)
 
-            await self.storage.pts(diff.state.pts)
-            await self.storage.date(diff.state.date)
+                for msg in diff.new_messages:
+                    self.dispatcher.updates_queue.put_nowait((
+                        raw.types.UpdateNewMessage(
+                            message=msg,
+                            pts=state.pts,
+                            pts_count=-1
+                        ),
+                        users,
+                        chats
+                    ))
+
+                for update in diff.other_updates:
+                    self.dispatcher.updates_queue.put_nowait((update, users, chats))
+
+                local_pts = state.pts
+                date = state.date
+                await self.storage.pts(local_pts)
+                await self.storage.date(date)
+
+                if isinstance(diff, raw.types.updates.Difference):
+                    break
         elif isinstance(updates, raw.types.UpdateShortSentMessage):
             local_pts = await self.storage.pts()
 
@@ -628,7 +647,6 @@ class Client(Methods, Scaffold):
                 return
 
             if local_pts + updates.pts_count != updates.pts:
-                log.warning('something is wrong, fallback to updates.getDifference')
                 return
 
             await self.storage.pts(updates.pts)

--- a/pyrogram/client.py
+++ b/pyrogram/client.py
@@ -172,6 +172,10 @@ class Client(Methods, Scaffold):
             Pass True to hide the password when typing it during the login.
             Defaults to False, because ``getpass`` (the library used) is known to be problematic in some
             terminal environments.
+
+        recover_gaps (``bool``, *optional*):
+            Pass True to fetching updates that arrived while the client was offline.
+            Defaults to False.
     """
 
     def __init__(
@@ -199,7 +203,8 @@ class Client(Methods, Scaffold):
         no_updates: bool = None,
         takeout: bool = None,
         sleep_threshold: int = Session.SLEEP_THRESHOLD,
-        hide_password: bool = False
+        hide_password: bool = False,
+        recover_gaps: bool = False
     ):
         super().__init__()
 
@@ -228,6 +233,7 @@ class Client(Methods, Scaffold):
         self.takeout = takeout
         self.sleep_threshold = sleep_threshold
         self.hide_password = hide_password
+        self.recover_gaps = recover_gaps
 
         self.executor = ThreadPoolExecutor(self.workers, thread_name_prefix="Handler")
 
@@ -591,6 +597,9 @@ class Client(Methods, Scaffold):
         elif isinstance(updates, raw.types.updates.State):
             local_pts = await self.storage.pts()
             date = await self.storage.date()
+
+            if self.recover_gaps is False:
+                return
 
             if local_pts >= updates.pts:
                 return

--- a/pyrogram/session/session.py
+++ b/pyrogram/session/session.py
@@ -258,8 +258,14 @@ class Session:
 
             if isinstance(msg.body, (raw.types.BadMsgNotification, raw.types.BadServerSalt)):
                 msg_id = msg.body.bad_msg_id
-            elif isinstance(msg.body, (FutureSalts, raw.types.RpcResult)):
+            elif isinstance(msg.body, FutureSalts):
                 msg_id = msg.body.req_msg_id
+            elif isinstance(msg.body, raw.types.RpcResult):
+                msg_id = msg.body.req_msg_id
+                result = getattr(msg.body, "result", None)
+                if isinstance(result, (raw.types.updates.State, raw.types.UpdateShortSentMessage)):
+                    if self.client is not None:
+                        self.loop.create_task(self.client.handle_updates(msg.body.result))
             elif isinstance(msg.body, raw.types.Pong):
                 msg_id = msg.body.msg_id
             else:

--- a/pyrogram/storage/file_storage.py
+++ b/pyrogram/storage/file_storage.py
@@ -76,6 +76,14 @@ class FileStorage(SQLiteStorage):
 
             version += 1
 
+        if version == 2:
+            with self.lock, self.conn:
+                self.conn.execute("ALTER TABLE sessions ADD COLUMN pts INTEGER DEFAULT(1)")
+                self.conn.execute("ALTER TABLE sessions ADD COLUMN qts INTEGER DEFAULT(-1)")
+                self.conn.execute("ALTER TABLE sessions ADD COLUMN seq INTEGER DEFAULT(0)")
+
+            version += 1
+
         self.version(version)
 
     async def open(self):

--- a/pyrogram/storage/sqlite_storage.py
+++ b/pyrogram/storage/sqlite_storage.py
@@ -35,7 +35,10 @@ CREATE TABLE sessions
     auth_key  BLOB,
     date      INTEGER NOT NULL,
     user_id   INTEGER,
-    is_bot    INTEGER
+    is_bot    INTEGER,
+    pts       INTEGER,
+    qts       INTEGER,
+    seq       INTEGER
 );
 
 CREATE TABLE peers
@@ -90,7 +93,7 @@ def get_input_peer(peer_id: int, access_hash: int, peer_type: str):
 
 
 class SQLiteStorage(Storage):
-    VERSION = 2
+    VERSION = 3
     USERNAME_TTL = 8 * 60 * 60
 
     def __init__(self, name: str):
@@ -109,8 +112,8 @@ class SQLiteStorage(Storage):
             )
 
             self.conn.execute(
-                "INSERT INTO sessions VALUES (?, ?, ?, ?, ?, ?)",
-                (2, None, None, 0, None, None)
+                "INSERT INTO sessions VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (2, None, None, 0, None, None, 1, -1, -1)
             )
 
     async def open(self):
@@ -208,6 +211,15 @@ class SQLiteStorage(Storage):
         return self._accessor(value)
 
     async def is_bot(self, value: bool = object):
+        return self._accessor(value)
+
+    async def pts(self, value: int = object):
+        return self._accessor(value)
+
+    async def qts(self, value: int = object):
+        return self._accessor(value)
+
+    async def seq(self, value: int = object):
         return self._accessor(value)
 
     def version(self, value: int = object):

--- a/pyrogram/storage/storage.py
+++ b/pyrogram/storage/storage.py
@@ -70,6 +70,15 @@ class Storage:
     async def is_bot(self, value: bool = object):
         raise NotImplementedError
 
+    async def pts(self, value: int = object):
+        raise NotImplementedError
+
+    async def qts(self, value: int = object):
+        raise NotImplementedError
+
+    async def seq(self, value: int = object):
+        raise NotImplementedError
+
     async def export_session_string(self):
         return base64.urlsafe_b64encode(
             struct.pack(


### PR DESCRIPTION
@delivrance 
The changes will allow the client to process `raw.types.RpcResult` `updates.State` to fetching updates that arrived while the client was offline.
At least the missed messages. I checked it on echobot.

To enable set `recover_gaps=True`