### PR TITLE
Display an error message to help solve the problem

### DIFF
--- a/pyrogram/client.py
+++ b/pyrogram/client.py
@@ -738,7 +738,7 @@ class Client(Methods, Scaffold):
                     try:
                         module = import_module(module_path)
                     except ImportError:
-                        log.warning(f'[{self.session_name}] [LOAD] Ignoring non-existent module "{module_path}"')
+                        log.warning(f'[{self.session_name}] [LOAD] Ignoring non-existent module "{module_path}" error is "{e}"')
                         continue
 
                     if "__path__" in dir(module):


### PR DESCRIPTION
If there is no error message when plugins are loaded, it will be very difficult for maintainers to know the problem and solve it.

Yesterday, I suddenly encountered the problem of not being able to load plugins, and later found out that a pip lib was not installed.