### PR TITLE
Fix: not always `r.full_chat.participants` has a `participants ` member.

### DIFF
--- a/pyrogram/methods/chats/get_chat_members.py
+++ b/pyrogram/methods/chats/get_chat_members.py
@@ -112,7 +112,7 @@ class GetChatMembers(Scaffold):
                 )
             )
 
-            members = r.full_chat.participants.participants
+            members = getattr(r.full_chat.participants, "participants", [])
             users = {i.id: i for i in r.users}
 
             return types.List(types.ChatMember._parse(self, member, users, {}) for member in members)


### PR DESCRIPTION
This should solve the error `AttributeError: 'ChatParticipantsForbidden' object has no attribute 'participants'` and apply the commit https://github.com/pyrogram/pyrogram/commit/062a6ce6dd8e9cbc9ee18d6c7c43bae5607ed215 on this file, too.