### PR TITLE
hotfix for iter_dialogs()

### DIFF
--- a/pyrogram/methods/chats/iter_dialogs.py
+++ b/pyrogram/methods/chats/iter_dialogs.py
@@ -77,7 +77,7 @@ class IterDialogs(Scaffold):
             
             print(len(dialogs))
             
-            if offset_date = dialogs[-1].top_message.date
+            if offset_date == dialogs[-1].top_message.date:
                 return
 
             offset_date = dialogs[-1].top_message.date

--- a/pyrogram/methods/chats/iter_dialogs.py
+++ b/pyrogram/methods/chats/iter_dialogs.py
@@ -77,7 +77,7 @@ class IterDialogs(Scaffold):
             
             print(len(dialogs))
             
-            if if not dialogs:
+            if not dialogs:
                 return
 
             offset_date = dialogs[-1].top_message.date

--- a/pyrogram/methods/chats/iter_dialogs.py
+++ b/pyrogram/methods/chats/iter_dialogs.py
@@ -76,10 +76,10 @@ class IterDialogs(Scaffold):
             )
             
             
-            if len(dialogs) <= 1:
+            if not dialogs:
                 return
 
-            offset_date = dialogs[-1].top_message.date
+            offset_date = dialogs[-1].top_message.date-1
 
             for dialog in dialogs:
                 yield dialog

--- a/pyrogram/methods/chats/iter_dialogs.py
+++ b/pyrogram/methods/chats/iter_dialogs.py
@@ -80,7 +80,7 @@ class IterDialogs(Scaffold):
             if not dialogs:
                 return
 
-            offset_date = dialogs[-1].top_message.date
+            offset_date = dialogs[-1].top_message.date+1
 
             for dialog in dialogs:
                 yield dialog

--- a/pyrogram/methods/chats/iter_dialogs.py
+++ b/pyrogram/methods/chats/iter_dialogs.py
@@ -77,10 +77,10 @@ class IterDialogs(Scaffold):
             
             print(len(dialogs))
             
-            if not dialogs:
+            if offset_date = dialogs[-1].top_message.date
                 return
 
-            offset_date = dialogs[-1].top_message.date+10
+            offset_date = dialogs[-1].top_message.date
 
             for dialog in dialogs:
                 yield dialog

--- a/pyrogram/methods/chats/iter_dialogs.py
+++ b/pyrogram/methods/chats/iter_dialogs.py
@@ -80,7 +80,7 @@ class IterDialogs(Scaffold):
             if not dialogs:
                 return
 
-            offset_date = dialogs[-1].top_message.date+1
+            offset_date = dialogs[-1].top_message.date+10
 
             for dialog in dialogs:
                 yield dialog

--- a/pyrogram/methods/chats/iter_dialogs.py
+++ b/pyrogram/methods/chats/iter_dialogs.py
@@ -75,7 +75,7 @@ class IterDialogs(Scaffold):
                 limit=limit
             )
 
-            if not dialogs:
+            if len(dialogs) <= 1:
                 return
 
             offset_date = dialogs[-1].top_message.date

--- a/pyrogram/methods/chats/iter_dialogs.py
+++ b/pyrogram/methods/chats/iter_dialogs.py
@@ -74,8 +74,10 @@ class IterDialogs(Scaffold):
                 offset_date=offset_date,
                 limit=limit
             )
-
-            if len(dialogs) <= 1:
+            
+            print(len(dialogs))
+            
+            if if not dialogs:
                 return
 
             offset_date = dialogs[-1].top_message.date

--- a/pyrogram/methods/chats/iter_dialogs.py
+++ b/pyrogram/methods/chats/iter_dialogs.py
@@ -75,9 +75,8 @@ class IterDialogs(Scaffold):
                 limit=limit
             )
             
-            print(len(dialogs))
             
-            if offset_date == dialogs[-1].top_message.date:
+            if len(dialogs) <= 1:
                 return
 
             offset_date = dialogs[-1].top_message.date


### PR DESCRIPTION
Telegram now always seems to return at least one dialog with the offset_date set to the oldest dialog. A hotfix was implemented to prevent endless loops.