### PR TITLE
Fix Message.command when case is different

### DIFF
--- a/pyrogram/filters.py
+++ b/pyrogram/filters.py
@@ -794,7 +794,8 @@ def command(commands: Union[str, List[str]], prefixes: Union[str, List[str]] = "
                                 flags=re.IGNORECASE if not flt.case_sensitive else 0):
                     continue
 
-                without_command = re.sub(rf"{cmd}(?:@?{username})?\s?", "", without_prefix, count=1)
+                without_command = re.sub(rf"{cmd}(?:@?{username})?\s?", "", without_prefix, count=1,
+                                         flags=re.IGNORECASE if not flt.case_sensitive else 0)
 
                 # match.groups are 1-indexed, group(1) is the quote, group(2) is the text
                 # between the quotes, group(3) is unquoted, whitespace-split text

--- a/tests/filters/test_command.py
+++ b/tests/filters/test_command.py
@@ -107,6 +107,10 @@ async def test_with_args():
     await f(c, m)
     assert m.command == ["start"]
 
+    m = Message("/StArT")
+    await f(c, m)
+    assert m.command == ["start"]
+
     m = Message("/start@username")
     await f(c, m)
     assert m.command == ["start"]


### PR DESCRIPTION
## Current behavior:

When using `filters.command("start")`, the `/start` command returns `["start"]` as expected, but `/START` returns `["start", "START"]`, which may cause issues if relying on `m.command` to get arguments.