### PR TITLE
Add: a new parameter `input_function` to Client

### DIFF
--- a/pyrogram/client.py
+++ b/pyrogram/client.py
@@ -202,7 +202,7 @@ class Client(Methods, Scaffold):
 
                 hide (``bool``, *optional*):
                     Determines whether the input should be hidden while is being typed.
-                    Determined by the `hide_password` parameter of ``~pyrogram.Client`.
+                    Determined by the `hide_password` parameter of ``~pyrogram.Client``.
                     Default is False.
             Example:
                 ..code-block:: python

--- a/pyrogram/client.py
+++ b/pyrogram/client.py
@@ -181,7 +181,7 @@ class Client(Methods, Scaffold):
 
             .. code-block:: python
 
-                def your_function(
+                async def your_function(
                     input_type: Scaffold.InputType,
                     formats: Sequence[str] = (),
                     hide: bool = False
@@ -206,7 +206,7 @@ class Client(Methods, Scaffold):
                     Default is False.
             Example:
                 ..code-block:: python
-                    def your_function(
+                    async def your_function(
                         input_type: Scaffold.InputType,
                         formats: Sequence[str] = (),
                         hide: bool = False

--- a/pyrogram/scaffold.py
+++ b/pyrogram/scaffold.py
@@ -17,6 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 import asyncio
+import enum
 import os
 import platform
 import re
@@ -50,6 +51,16 @@ class Scaffold:
 
     mimetypes = MimeTypes()
     mimetypes.readfp(StringIO(mime_types))
+
+    class InputType(enum.Enum):
+        EnterPhoneOrToken = 'Enter phone number or bot token: '
+        IsPhoneCorrect = 'Is "{}" correct? (y/N): '
+        EnterConfirmationCode = 'Enter confirmation code: '
+        EnterPassword = 'Enter password (empty to recover): '
+        ConfirmPasswordRecovery = 'Confirm password recovery (y/n): '
+        EnterRecoveryCode = 'Enter recovery code: '
+        EnterFirstName = 'Enter first name: '
+        EnterLastName = 'Enter last name (empty to skip): '
 
     def __init__(self):
         try:

--- a/pyrogram/utils.py
+++ b/pyrogram/utils.py
@@ -24,16 +24,27 @@ import os
 import struct
 from concurrent.futures.thread import ThreadPoolExecutor
 from getpass import getpass
-from typing import Union, List, Dict, Optional
+from typing import Union, List, Dict, Optional, Sequence
 
 import pyrogram
 from pyrogram import raw
 from pyrogram import types
+from pyrogram import scaffold
 from pyrogram.file_id import FileId, FileType, PHOTO_TYPES, DOCUMENT_TYPES
 
 
-async def ainput(prompt: str = "", *, hide: bool = False):
+async def ainput(
+        input_type: scaffold.Scaffold.InputType = None,
+        formats: Sequence[str] = (),
+        *,
+        hide: bool = False
+) -> str:
     """Just like the built-in input, but async"""
+    prompt = ""
+    if input_type:
+        prompt = input_type.value
+    if formats:
+        prompt = prompt.format(*formats)
     with ThreadPoolExecutor(1) as executor:
         func = functools.partial(getpass if hide else input, prompt)
         return await asyncio.get_event_loop().run_in_executor(executor, func)


### PR DESCRIPTION
The idea is to allow users to give input without having to type it in the console, but prepared inputs.
The function should be defined as follows and always must return a string which will be passed as the input.

`input_type` is the required input.
`formats` is a tuple containing the strings that should be formatted into the original prompt (if needed).
`hide` determines whether the input should be hidden while is being typed or not (in case it's "secret" like entering 2FA password).

```python
async def your_function(
    input_type: Scaffold.InputType,
    formats: Sequence[str] = (),
    hide: bool = False
) -> str: ...
```

For example, their input could be brought this way:

```python
async def your_function(
    input_type: Scaffold.InputType,
    formats: Sequence[str] = (),
    hide: bool = False
) -> str:
    if input_type == Scaffold.InputType.EnterPhoneOrToken:
        return PHONE_NUMBER
  
    # Make sure to handle all inputs correctly.
```

You have to handle all types of inputs so the function could always return a corresponding string.
You can also add a default `input` function with the original prompt:

```python
else:
    return await pyrogram.utils.ainput(input_type.value.format(*formats))
```

