### PR TITLE
Add argument to preset bot commands list

### DIFF
--- a/pyrogram/methods/utilities/run.py
+++ b/pyrogram/methods/utilities/run.py
@@ -24,7 +24,7 @@ from pyrogram.scaffold import Scaffold
 
 
 class Run(Scaffold):
-    def run(self, coroutine=None):
+    def run(self, coroutine=None, bot_commands=None):
         """Start the client, idle the main script and finally stop the client.
 
         This is a convenience method that calls :meth:`~pyrogram.Client.start`, :meth:`~pyrogram.idle` and
@@ -59,5 +59,6 @@ class Run(Scaffold):
                 run(self.stop())
             else:
                 self.start()
+                self.set_bot_commands(bot_commands)
                 run(idle())
                 self.stop()

--- a/pyrogram/methods/utilities/run.py
+++ b/pyrogram/methods/utilities/run.py
@@ -59,6 +59,11 @@ class Run(Scaffold):
                 run(self.stop())
             else:
                 self.start()
-                self.set_bot_commands(bot_commands)
+
+                try:
+                    self.set_bot_commands(bot_commands)
+                except:
+                    pass
+
                 run(idle())
                 self.stop()


### PR DESCRIPTION
I'm not sure about that, but at the moment there isn't a easy way to preset the bot commands list before user interaction; if we try to call `Client.set_bot_commands(...)` before `Client.run()` we get this traceback:

```
Traceback (most recent call last):
  File "/home/v0lp3/ftth_checker/bot.py", line 177, in <module>
    app.set_bot_commands([])
  File "/home/v0lp3/ftth_checker/venv/lib/python3.9/site-packages/pyrogram/sync.py", line 51, in async_to_sync_wrap
    return loop.run_until_complete(coroutine)
  File "/usr/lib/python3.9/asyncio/base_events.py", line 642, in run_until_complete
    return future.result()
  File "/home/v0lp3/ftth_checker/venv/lib/python3.9/site-packages/pyrogram/methods/bots/set_bot_commands.py", line 60, in set_bot_commands
    return await self.send(
  File "/home/v0lp3/ftth_checker/venv/lib/python3.9/site-packages/pyrogram/methods/advanced/send.py", line 69, in send
    raise ConnectionError("Client has not been started yet")
ConnectionError: Client has not been started yet
```
I have added an argument with default `None` value to the run script.
