### PR TITLE
fix for client.download_media consistently fails for photos for big channels -503 Timeout #664

### DIFF
--- a/pyrogram/client.py
+++ b/pyrogram/client.py
@@ -916,9 +916,6 @@ class Client(Methods, Scaffold):
                     while True:
                         chunk = r.bytes
 
-                        if not chunk:
-                            break
-
                         f.write(chunk)
 
                         offset += limit
@@ -938,6 +935,9 @@ class Client(Methods, Scaffold):
                             else:
                                 await self.loop.run_in_executor(self.executor, func)
 
+                        if len(chunk) < limit:
+                            break        
+                        
                         r = await session.send(
                             raw.functions.upload.GetFile(
                                 location=location,


### PR DESCRIPTION
some times server don't send response if offset more then file size (i think some file storages don't support this behavior)

so fix in one line: need change condition for break loop to len(chunk) < limit