### PR TITLE
make bot username optional

### DIFF
--- a/pyrogram/types/bots_and_keyboards/inline_keyboard_button.py
+++ b/pyrogram/types/bots_and_keyboards/inline_keyboard_button.py
@@ -147,7 +147,7 @@ class InlineKeyboardButton(Object):
         if self.login_url is not None:
             return self.login_url.write(
                 text=self.text,
-                bot=await client.resolve_peer(self.login_url.bot_username)
+                bot=await client.resolve_peer(self.login_url.bot_username or "self")
             )
 
         if self.switch_inline_query is not None:

--- a/pyrogram/types/bots_and_keyboards/login_url.py
+++ b/pyrogram/types/bots_and_keyboards/login_url.py
@@ -31,7 +31,8 @@ class LoginUrl(Object):
         url (``str``):
             An HTTP URL to be opened with user authorization data added to the query string when the button is pressed.
             If the user refuses to provide authorization data, the original URL without information about the user will
-            be opened. The data added is the same as described in Receiving authorization data.
+            be opened. The data added is the same as described in
+            `Receiving authorization data <https://core.telegram.org/widgets/login#receiving-authorization-data>`.
 
             **NOTE**: You **must** always check the hash of the received data to verify the authentication and the
             integrity of the data as described in

--- a/pyrogram/types/bots_and_keyboards/login_url.py
+++ b/pyrogram/types/bots_and_keyboards/login_url.py
@@ -43,7 +43,7 @@ class LoginUrl(Object):
 
         bot_username (``str``, *optional*):
             Username of a bot, which will be used for user authorization.
-            See `Setting up <https://core.telegram.org/widgets/login#setting-up-a-bot>`_ a bot for more details.
+            See `Setting up a bot <https://core.telegram.org/widgets/login#setting-up-a-bot>`_ for more details.
             If not specified, the current bot's username will be assumed. The url's domain must be the same as the
             domain linked with the bot.
             See `Linking your domain to the bot <https://core.telegram.org/widgets/login#linking-your-domain-to-the-bot>`_


### PR DESCRIPTION
According to the docs, bot username is optional
see - https://docs.pyrogram.org/api/types/LoginUrl#pyrogram.types.LoginUrl