### PR TITLE
Fixing `export_session_string` the right way

### DIFF
--- a/pyrogram/storage/memory_storage.py
+++ b/pyrogram/storage/memory_storage.py
@@ -36,7 +36,8 @@ class MemoryStorage(SQLiteStorage):
 
         if self.name != ":memory:":
             dc_id, test_mode, auth_key, user_id, is_bot = struct.unpack(
-                self.SESSION_STRING_FORMAT,
+                (self.SESSION_STRING_FORMAT if len(self.name) == MemoryStorage.SESSION_STRING_SIZE else
+                 self.SESSION_STRING_FORMAT_64),
                 base64.urlsafe_b64decode(
                     self.name + "=" * (-len(self.name) % 4)
                 )

--- a/pyrogram/storage/storage.py
+++ b/pyrogram/storage/storage.py
@@ -20,10 +20,14 @@ import base64
 import struct
 from typing import List, Tuple
 
+from pyrogram import utils
+
 
 class Storage:
     SESSION_STRING_FORMAT = ">B?256sI?"
+    SESSION_STRING_FORMAT_64 = ">B?256sQ?"
     SESSION_STRING_SIZE = 351
+    SESSION_STRING_SIZE_64 = 356
 
     def __init__(self, name: str):
         self.name = name
@@ -71,13 +75,14 @@ class Storage:
         raise NotImplementedError
 
     async def export_session_string(self):
+        user_id = await self.user_id()
         return base64.urlsafe_b64encode(
             struct.pack(
-                self.SESSION_STRING_FORMAT,
+                self.SESSION_STRING_FORMAT if user_id < utils.MAX_USER_ID_OLD else self.SESSION_STRING_FORMAT_64,
                 await self.dc_id(),
                 await self.test_mode(),
                 await self.auth_key(),
-                await self.user_id(),
+                user_id,
                 await self.is_bot()
             )
         ).decode().rstrip("=")

--- a/pyrogram/utils.py
+++ b/pyrogram/utils.py
@@ -159,6 +159,7 @@ def unpack_inline_message_id(inline_message_id: str) -> "raw.types.InputBotInlin
 MIN_CHANNEL_ID = -1002147483647
 MAX_CHANNEL_ID = -1000000000000
 MIN_CHAT_ID = -2147483647
+MAX_USER_ID_OLD = 2147483647
 MAX_USER_ID = 999999999999
 
 


### PR DESCRIPTION
This is the old issue I was trying to open, but then I just found a way to duel with it.

<details>
<summary> Old Issue I was going to post </summary>

> Since Telegram had upgraded the `user_id` to `int64` data type,
I'was wondering how can we fix the problem when the user/bot's id is a `int64`?
>
> https://github.com/pyrogram/pyrogram/blob/bf9e1864141bdab1a4f20393c7d10fcf8c522f63/pyrogram/storage/storage.py#L73-L83
> The code below shows how `export_session_string` works
>
> https://github.com/pyrogram/pyrogram/blob/bf9e1864141bdab1a4f20393c7d10fcf8c522f63/pyrogram/storage/storage.py#L25
> This is the problem, `">B?256sI?"` is not competable for `int64`. The `I` is only for `unsigned int` as shown in official document in `Python`.
> If we need to fix it, we need to change it to `">B?256sQ?"` which may break older session string.
>
> I get it, I am stupid. I can just check for it's length to determine!

</details>

I fixed the backward compatibility by checking it's length;
for the generating, I just check for `user_id`, if that's a `int64` then use `">B?256sQ?"` else use the old one.

I got this issue when I tried to `export_session_string` with new created bot.

Edit 2
---

I've checked and there is already a PR trying to fixing this problem: #802
But that may break the `backward compatibility`.

---

Here are some part that I think it could be improved:

`pyrogram/utils.py`
```diff
MIN_CHANNEL_ID = -1002147483647
MAX_CHANNEL_ID = -1000000000000
MIN_CHAT_ID = -2147483647
+ MAX_USER_ID_OLD = 2147483647
MAX_USER_ID = 999999999999
```

The value `MAX_USER_ID_OLD` is added because of the following code:
`pyrogram/storage/storage.py`
```diff
    async def export_session_string(self):
+      user_id = await self.user_id()
        return base64.urlsafe_b64encode(
            struct.pack(
-              self.SESSION_STRING_FORMAT,
+              self.SESSION_STRING_FORMAT if user_id < utils.MAX_USER_ID_OLD else self.SESSION_STRING_FORMAT_64,
                await self.dc_id(),
                await self.test_mode(),
                await self.auth_key(),
-               await self.user_id(),
+              user_id,
                await self.is_bot()
            )
        ).decode().rstrip("=")
```

Can this be replaced by just `2147483647`? But after coding it I think it's not beautiful because it looks like hard-coded.

Edit 1:
---
Should we still fallback to `utils.MAX_USER_ID_OLD` while Telegram has already changed all data type to `int64`?

I mean,
`pyrogram/storage/storage.py`
```diff
- self.SESSION_STRING_FORMAT if user_id < utils.MAX_USER_ID_OLD else self.SESSION_STRING_FORMAT_64
+ self.SESSION_STRING_FORMAT_64
```
---

Second,

`pyrogram/storage/memory_storage.py`
```diff
-               self.SESSION_STRING_FORMAT,
+               (self.SESSION_STRING_FORMAT if len(self.name) == MemoryStorage.SESSION_STRING_SIZE else
+                self.SESSION_STRING_FORMAT_64),
```

Is this too ugly? I don't know how to write this properly.