### PR TITLE
include tests in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 ## Include
 include README.md COPYING COPYING.lesser NOTICE requirements.txt
 recursive-include compiler *.py *.tl *.tsv *.txt
+recursive-include tests *.py
 
 ## Exclude
 prune pyrogram/errors/exceptions


### PR DESCRIPTION
This allows distributions to run the tests when packaging pyrogram, which guarantees that it works well with the versions of pyrogram's dependencies that the distribution ships.