### PR TITLE
Fix `KeyError` when user(64-bit ID) send a message to himself

### DIFF
--- a/pyrogram/types/messages_and_media/message.py
+++ b/pyrogram/types/messages_and_media/message.py
@@ -445,15 +445,16 @@ class Message(Object, Update):
         peer_id = utils.get_raw_peer_id(message.peer_id)
         user_id = from_id or peer_id
 
-        if isinstance(message.from_id, raw.types.PeerUser) and isinstance(message.peer_id, raw.types.PeerUser):
+        if isinstance(message.from_id, raw.types.PeerUser) or isinstance(message.peer_id, raw.types.PeerUser):
             if from_id not in users or peer_id not in users:
                 try:
+                    id = [await client.resolve_peer(peer_id)]
+                    if from_id:
+                        id += [await client.resolve_peer(from_id)]
+
                     r = await client.send(
                         raw.functions.users.GetUsers(
-                            id=[
-                                await client.resolve_peer(from_id),
-                                await client.resolve_peer(peer_id)
-                            ]
+                            id=id
                         )
                     )
                 except PeerIdInvalid:


### PR DESCRIPTION
When a new client user(64-bit ID) tries to send himself a message like this:
```
app.send_message("me", "Test")
```
He receives an `Key Error` .
> The message is sent successfully but the code is broken and this error occurs.



## Details:

```
Traceback (most recent call last):
  File "/home/zanko/.local/lib/python3.9/site-packages/pyrogram/dispatcher.py", line 217, in handler_worker
    await handler.callback(self.client, *args)
  File "/home/zanko/Videos/move2020/Animi/ranger war/create_session/test1/33.py", line 20, in x
    await app.send_message("me", "Test")
  File "/home/zanko/.local/lib/python3.9/site-packages/pyrogram/methods/messages/send_message.py", line 170, in send_message
    return await types.Message._parse(
  File "/home/zanko/.local/lib/python3.9/site-packages/pyrogram/types/messages_and_media/message.py", line 677, in _parse
    sender_chat = types.Chat._parse(client, message, users, chats, is_chat=False) if not from_user else None
  File "/home/zanko/.local/lib/python3.9/site-packages/pyrogram/types/user_and_chats/chat.py", line 253, in _parse
    return Chat._parse_user_chat(client, users[chat_id])
KeyError: 5068773474
```

This error happen because raw method `raw.functions.messages.SendMessage` doesn't return full update means users field is empty :
```
    "users": [],
    "chats": [],
    "date": 1640900272,
    "seq": 0
```
And when it reaches the `_parse` function in `types/messages_and_media/message.py` message.from_id return the None value, then this condition doesn't execute:
 ```
if isinstance(message.from_id, raw.types.PeerUser) and isinstance(message.peer_id, raw.types.PeerUser)
```
Finally, users dictionary is not updated(within the condition) and as you can see in the error, there is no key for **chat_id** inside users.
