### PR TITLE
Fix spoiler html unparsing

### DIFF
--- a/pyrogram/parser/html.py
+++ b/pyrogram/parser/html.py
@@ -155,10 +155,10 @@ class HTML:
             start = entity.offset
             end = start + entity.length
 
-            if entity_type in ("bold", "italic", "underline", "strikethrough", "spoiler"):
+            if entity_type in ("bold", "italic", "underline", "strikethrough"):
                 start_tag = f"<{entity_type[0]}>"
                 end_tag = f"</{entity_type[0]}>"
-            elif entity_type in ("code", "pre", "blockquote"):
+            elif entity_type in ("code", "pre", "blockquote", "spoiler"):
                 start_tag = f"<{entity_type}>"
                 end_tag = f"</{entity_type}>"
             elif entity_type == "text_link":


### PR DESCRIPTION
- The current spoiler implementaion unparses both strikethrough and spoiler tags with \<s\>, making them indistinguishable:

![](https://user-images.githubusercontent.com/29029632/148616941-8b0f361c-771b-4f18-9678-72649ffdbf28.png)
