### PR TITLE
🐛 [Bug fixes] `compiler.py` and `future_salts.py`

### DIFF
--- a/compiler/api/compiler.py
+++ b/compiler/api/compiler.py
@@ -447,7 +447,7 @@ def start(format: bool = False):
                     )
 
                     read_types += "\n        "
-                    read_types += "{} = TLObject.read(b{}) if flags & (1 << {}) else []\n        ".format(
+                    read_types += "{} = TLObject.read(b{}) if flags & (1 << {}) else None\n        ".format(
                         arg_name, f", {sub_type.title()}" if sub_type in CORE_TYPES else "", index
                     )
                 else:

--- a/pyrogram/raw/core/future_salts.py
+++ b/pyrogram/raw/core/future_salts.py
@@ -48,6 +48,7 @@ class FutureSalts(TLObject):
 
     def write(self, *args: Any) -> bytes:
         b = BytesIO()
+        b.write(Int(self.ID, False))
 
         b.write(Long(self.req_msg_id))
         b.write(Int(self.now))


### PR DESCRIPTION
`compiler/api/compiler.py`
- Vector can cause empty `TLObject` sent when calling `write()`

`pyrogram/raw/core/future_salts.py`
- `ID` value missing in `write()`, can cause server to reject and force disconnect you.

This is tested by watsing 13 hours.