### PR TITLE
Now unparses overlapped entities

### DIFF
--- a/pyrogram/parser/html.py
+++ b/pyrogram/parser/html.py
@@ -174,8 +174,17 @@ class HTML:
 
             entities_offsets.append((start_tag, start,))
             entities_offsets.append((end_tag, end,))
+            
+        entities_offsets = map(
+            lambda x: x[1],
+            sorted(
+                enumerate(entities_offsets),
+                key = lambda x: (x[1][1], x[0]),
+                reverse = True
+            )
+        )
 
-        for entity, offset in reversed(entities_offsets):
+        for entity, offset in entities_offsets:
             text = text[:offset] + entity + text[offset:]
 
         return utils.remove_surrogates(text)


### PR DESCRIPTION
Simple reversed method didn't work with overlapping entities