### PR TITLE
Invert storage loading order (for mypy)

### DIFF
--- a/pyrogram/client.py
+++ b/pyrogram/client.py
@@ -233,14 +233,14 @@ class Client(Methods, Scaffold):
 
         self.executor = ThreadPoolExecutor(self.workers, thread_name_prefix="Handler")
 
-        if isinstance(session_name, str):
+        if isinstance(session_name, Storage):
+            self.storage = session_name
+        elif isinstance(session_name, str):
             if session_name == ":memory:" or len(session_name) >= MemoryStorage.SESSION_STRING_SIZE:
                 session_name = re.sub(r"[\n\s]+", "", session_name)
                 self.storage = MemoryStorage(session_name)
             else:
                 self.storage = FileStorage(session_name, self.workdir)
-        elif isinstance(session_name, Storage):
-            self.storage = session_name
         else:
             raise ValueError("Unknown storage engine")
 


### PR DESCRIPTION
mypy assumed Client.storage is of type MemoryStorage because the first time self.storage gets assigned (in code), it's of MemoryStorage type.

Move the generic Storage assignation before. Has no effect on behavior, but makes mypy know Client.storage is of type Storage.
As bonus points, makes even more clear for readers that you can pass a custom Storage type as name.

(putting `storage : Storage` in Client definition would also solve this)