### PR TITLE
Will now also catch "x was accepted in the group" updates via filters

### DIFF
--- a/pyrogram/types/messages_and_media/message.py
+++ b/pyrogram/types/messages_and_media/message.py
@@ -498,7 +498,7 @@ class Message(Object, Update):
             if isinstance(action, raw.types.MessageActionChatAddUser):
                 new_chat_members = [types.User._parse(client, users[i]) for i in action.users]
                 service_type = "new_chat_members"
-            elif isinstance(action, raw.types.MessageActionChatJoinedByLink):
+            elif isinstance(action, raw.types.MessageActionChatJoinedByLink) or isinstance(action, raw.types.MessageActionChatJoinedByRequest):
                 new_chat_members = [types.User._parse(client, users[utils.get_raw_peer_id(message.from_id)])]
                 service_type = "new_chat_members"
             elif isinstance(action, raw.types.MessageActionChatDeleteUser):


### PR DESCRIPTION
The `new_chat_members` and `service` filter will also catch "x was accepted to the group" updates
I have tested the changes in my local machine and its working fine

_I am pretty new to contributions, so please guide me if I am doing anything wrong, thanks :)_