### PR TITLE
Fix / implement JSON .session upgrades in FileStorage

### DIFF
--- a/pyrogram/storage/file_storage.py
+++ b/pyrogram/storage/file_storage.py
@@ -36,15 +36,15 @@ class FileStorage(SQLiteStorage):
 
         self.database = workdir / (self.name + self.FILE_EXTENSION)
 
-    def migrate_from_json(self, session_json: dict):
-        self.open()
+    async def migrate_from_json(self, session_json: dict):
+        await self.open()
 
-        self.dc_id(session_json["dc_id"])
-        self.test_mode(session_json["test_mode"])
-        self.auth_key(base64.b64decode("".join(session_json["auth_key"])))
-        self.user_id(session_json["user_id"])
-        self.date(session_json.get("date", 0))
-        self.is_bot(session_json.get("is_bot", False))
+        await self.dc_id(session_json["dc_id"])
+        await self.test_mode(session_json["test_mode"])
+        await self.auth_key(base64.b64decode("".join(session_json["auth_key"])))
+        await self.user_id(session_json["user_id"])
+        await self.date(session_json.get("date", 0))
+        await self.is_bot(session_json.get("is_bot", False))
 
         peers_by_id = session_json.get("peers_by_id", {})
         peers_by_phone = session_json.get("peers_by_phone", {})
@@ -65,7 +65,7 @@ class FileStorage(SQLiteStorage):
             peers[v][4] = k
 
         # noinspection PyTypeChecker
-        self.update_peers(peers.values())
+        await self.update_peers(peers.values())
 
     def update(self):
         version = self.version()
@@ -95,7 +95,7 @@ class FileStorage(SQLiteStorage):
 
                 log.warning(f'The old session file has been renamed to "{path.name}.OLD"')
 
-                self.migrate_from_json(session_json)
+                await self.migrate_from_json(session_json)
 
                 log.warning("Done! The session has been successfully converted from JSON to SQLite storage")
 

--- a/pyrogram/storage/file_storage.py
+++ b/pyrogram/storage/file_storage.py
@@ -63,23 +63,34 @@ class FileStorage(SQLiteStorage):
         await self.user_id(session_json["user_id"])
         await self.date(session_json.get("date", 0))
         await self.is_bot(session_json.get("is_bot", False))
-
+        
+        # id : access_hash
         peers_by_id = session_json.get("peers_by_id", {})
+
+        # id : username by reversing the dict.
         peers_by_username = reverse_dict(session_json.get("peers_by_username", {}))
+        
+        # id : phone by reversing the dict.
         peers_by_phone = reverse_dict(session_json.get("peers_by_phone", {}))
 
         peers = {}
 
         for k, v in peers_by_id.items():
+            
+            # intuitively type guess with access_hash
             if v is None:
                 type_ = "group"
             elif k.startswith("-100"):
                 type_ = "channel"
             else:
                 type_ = "user"
-            
+            # generate a new row, [id, access_hash, type, None, None]
             peers[int(k)] = [int(k), int(v) if v is not None else None, type_, None, None]
+            
+            # add the username in [id, access_hash, type, username, None] (if it exists)
             peers[int(k)][3] = peers_by_username[k] if k in peers_by_username else None
+            
+            # add the phone number [id, access_hash, type, username, phone] (if it exists)
             peers[int(k)][4] = peers_by_phone[k] if k in peers_by_phone else None
 
 


### PR DESCRIPTION
Had some old JSON formatted .sessions that needed to be upgraded. However, there were a lot of issues with the code that was already in the library. I was actually manually converting the data when I needed to figure out how to get the types for bots and supergroups. 

I noticed Pyrogram was able to do this, but when I was looking through the source to find out how, I noticed methods already in place for upgrading the JSON sessions. Upon trying to use them though, they were littered with errors, and also did not fully support all the data (specifically usernames were ALL null).

So I went ahead and modified what was there. Correctly handling the coroutines being called, and also implementing the addition of usernames to the list. I also cleaned up the code by removing some of the unnecessary iteration of keys and values by doing a key:value swap on the peers_by_* dicts.


I have tested the changes with a JSON formatted .session file created in Pyrogram 0.11.0.

I installed my fork on a clean virtual environment running `Python 3.10.2`, on `Windows 10`, using `py -m pip install git+https://github.com/VoxLight/pyrogram#egg=pyrogram`.


This pull can close #918 