### PR TITLE
Fix BytesIO support 

### DIFF
--- a/pyrogram/methods/messages/edit_inline_media.py
+++ b/pyrogram/methods/messages/edit_inline_media.py
@@ -18,6 +18,7 @@
 
 import os
 import re
+import io
 
 from pyrogram import raw
 from pyrogram import types
@@ -73,7 +74,7 @@ class EditInlineMedia(Scaffold):
         parse_mode = media.parse_mode
 
         if isinstance(media, types.InputMediaPhoto):
-            if os.path.isfile(media.media):
+            if isinstance(media.media, io.BytesIO) or os.path.isfile(media.media):
                 media = raw.types.InputMediaUploadedPhoto(
                     file=await self.save_file(media.media)
                 )
@@ -84,7 +85,7 @@ class EditInlineMedia(Scaffold):
             else:
                 media = utils.get_input_media_from_file_id(media.media, FileType.PHOTO)
         elif isinstance(media, types.InputMediaVideo):
-            if os.path.isfile(media.media):
+            if isinstance(media.media, io.BytesIO) or os.path.isfile(media.media):
                 media = raw.types.InputMediaUploadedDocument(
                     mime_type=self.guess_mime_type(media.media) or "video/mp4",
                     thumb=await self.save_file(media.thumb),
@@ -108,7 +109,7 @@ class EditInlineMedia(Scaffold):
             else:
                 media = utils.get_input_media_from_file_id(media.media, FileType.VIDEO)
         elif isinstance(media, types.InputMediaAudio):
-            if os.path.isfile(media.media):
+            if isinstance(media.media, io.BytesIO) or os.path.isfile(media.media):
                 media = raw.types.InputMediaUploadedDocument(
                     mime_type=self.guess_mime_type(media.media) or "audio/mpeg",
                     thumb=await self.save_file(media.thumb),
@@ -131,7 +132,7 @@ class EditInlineMedia(Scaffold):
             else:
                 media = utils.get_input_media_from_file_id(media.media, FileType.AUDIO)
         elif isinstance(media, types.InputMediaAnimation):
-            if os.path.isfile(media.media):
+            if isinstance(media.media, io.BytesIO) or os.path.isfile(media.media):
                 media = raw.types.InputMediaUploadedDocument(
                     mime_type=self.guess_mime_type(media.media) or "video/mp4",
                     thumb=await self.save_file(media.thumb),
@@ -156,7 +157,7 @@ class EditInlineMedia(Scaffold):
             else:
                 media = utils.get_input_media_from_file_id(media.media, FileType.ANIMATION)
         elif isinstance(media, types.InputMediaDocument):
-            if os.path.isfile(media.media):
+            if isinstance(media.media, io.BytesIO) or os.path.isfile(media.media):
                 media = raw.types.InputMediaUploadedDocument(
                     mime_type=self.guess_mime_type(media.media) or "application/zip",
                     thumb=await self.save_file(media.thumb),

--- a/pyrogram/methods/messages/edit_message_media.py
+++ b/pyrogram/methods/messages/edit_message_media.py
@@ -18,6 +18,7 @@
 
 import os
 import re
+import io
 from typing import Union
 
 from pyrogram import raw
@@ -86,7 +87,7 @@ class EditMessageMedia(Scaffold):
             message, entities = (await self.parser.parse(caption, parse_mode)).values()
 
         if isinstance(media, types.InputMediaPhoto):
-            if os.path.isfile(media.media):
+            if isinstance(media.media, io.BytesIO) or os.path.isfile(media.media):
                 media = await self.send(
                     raw.functions.messages.UploadMedia(
                         peer=await self.resolve_peer(chat_id),
@@ -110,7 +111,7 @@ class EditMessageMedia(Scaffold):
             else:
                 media = utils.get_input_media_from_file_id(media.media, FileType.PHOTO)
         elif isinstance(media, types.InputMediaVideo):
-            if os.path.isfile(media.media):
+            if isinstance(media.media, io.BytesIO) or os.path.isfile(media.media):
                 media = await self.send(
                     raw.functions.messages.UploadMedia(
                         peer=await self.resolve_peer(chat_id),
@@ -147,7 +148,7 @@ class EditMessageMedia(Scaffold):
             else:
                 media = utils.get_input_media_from_file_id(media.media, FileType.VIDEO)
         elif isinstance(media, types.InputMediaAudio):
-            if os.path.isfile(media.media):
+            if isinstance(media.media, io.BytesIO) or os.path.isfile(media.media):
                 media = await self.send(
                     raw.functions.messages.UploadMedia(
                         peer=await self.resolve_peer(chat_id),
@@ -183,7 +184,7 @@ class EditMessageMedia(Scaffold):
             else:
                 media = utils.get_input_media_from_file_id(media.media, FileType.AUDIO)
         elif isinstance(media, types.InputMediaAnimation):
-            if os.path.isfile(media.media):
+            if isinstance(media.media, io.BytesIO) or os.path.isfile(media.media):
                 media = await self.send(
                     raw.functions.messages.UploadMedia(
                         peer=await self.resolve_peer(chat_id),
@@ -221,7 +222,7 @@ class EditMessageMedia(Scaffold):
             else:
                 media = utils.get_input_media_from_file_id(media.media, FileType.ANIMATION)
         elif isinstance(media, types.InputMediaDocument):
-            if os.path.isfile(media.media):
+            if isinstance(media.media, io.BytesIO) or os.path.isfile(media.media):
                 media = await self.send(
                     raw.functions.messages.UploadMedia(
                         peer=await self.resolve_peer(chat_id),

--- a/pyrogram/types/input_media/input_media.py
+++ b/pyrogram/types/input_media/input_media.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import List
+from typing import List, Union, BinaryIO
 
 from ..messages_and_media import MessageEntity
 from ..object import Object
@@ -36,7 +36,7 @@ class InputMedia(Object):
 
     def __init__(
         self,
-        media: str,
+        media: Union[str, BinaryIO],
         caption: str = "",
         parse_mode: str = None,
         caption_entities: List[MessageEntity] = None

--- a/pyrogram/types/input_media/input_media_animation.py
+++ b/pyrogram/types/input_media/input_media_animation.py
@@ -26,7 +26,7 @@ class InputMediaAnimation(InputMedia):
     """An animation file (GIF or H.264/MPEG-4 AVC video without sound) to be sent inside an album.
 
     Parameters:
-        media (``str``):
+        media (``str`` | ``BinaryIO``):
             Animation to send.
             Pass a file_id as string to send a file that exists on the Telegram servers or
             pass a file path as string to upload a new file that exists on your local machine or

--- a/pyrogram/types/input_media/input_media_audio.py
+++ b/pyrogram/types/input_media/input_media_audio.py
@@ -28,7 +28,7 @@ class InputMediaAudio(InputMedia):
     It is intended to be used with :meth:`~pyrogram.Client.send_media_group`.
 
     Parameters:
-        media (``str``):
+        media (``str`` | ``BinaryIO``):
             Audio to send.
             Pass a file_id as string to send an audio that exists on the Telegram servers or
             pass a file path as string to upload a new audio that exists on your local machine or

--- a/pyrogram/types/input_media/input_media_document.py
+++ b/pyrogram/types/input_media/input_media_document.py
@@ -26,7 +26,7 @@ class InputMediaDocument(InputMedia):
     """A generic file to be sent inside an album.
 
     Parameters:
-        media (``str``):
+        media (``str`` | ``BinaryIO``):
             File to send.
             Pass a file_id as string to send a file that exists on the Telegram servers or
             pass a file path as string to upload a new file that exists on your local machine or

--- a/pyrogram/types/input_media/input_media_video.py
+++ b/pyrogram/types/input_media/input_media_video.py
@@ -27,7 +27,7 @@ class InputMediaVideo(InputMedia):
     It is intended to be used with :obj:`~pyrogram.Client.send_media_group`.
 
     Parameters:
-        media (``str``):
+        media (``str`` | ``BinaryIO``):
             Video to send.
             Pass a file_id as string to send a video that exists on the Telegram servers or
             pass a file path as string to upload a new video that exists on your local machine or


### PR DESCRIPTION
I noticed that when editing a media passing an io.BytesIO object to the input media like this:

```python
mypic = Image.new("RGB", (512, 512), "black")
b = io.BytesIO()
mypic.save(b, "PNG")
await client.edit_message_media(chat_id, message_id, media=InputMediaPhoto(b))
```
It raises:

```
TypeError: stat: path should be string, bytes, os.PathLike or integer, not BytesIO
```

also some docstrings didn't mention the BinaryIO type for some parameters  