### PR TITLE
faster pyrogram lre encode implementation

### DIFF
--- a/pyrogram/file_id.py
+++ b/pyrogram/file_id.py
@@ -21,6 +21,7 @@ import logging
 import struct
 from enum import IntEnum
 from io import BytesIO
+from typing import List
 
 from pyrogram.raw.core import Bytes, String
 
@@ -63,7 +64,7 @@ def rle_encode(s: bytes) -> bytes:
     Returns:
         ``bytes``: The encoded bytes
     """
-    r: bytes = b""
+    r: List[int] = []
     n: int = 0
 
     for b in s:
@@ -71,15 +72,15 @@ def rle_encode(s: bytes) -> bytes:
             n += 1
         else:
             if n:
-                r += bytes([0, n])
+                r.extend((0, n))
                 n = 0
 
-            r += bytes([b])
+            r.append(b)
 
     if n:
-        r += bytes([0, n])
+        r.extend((0, n))
 
-    return r
+    return bytes(r)
 
 
 def rle_decode(s: bytes) -> bytes:

--- a/pyrogram/file_id.py
+++ b/pyrogram/file_id.py
@@ -93,7 +93,7 @@ def rle_decode(s: bytes) -> bytes:
     Returns:
         ``bytes``: The decoded bytes
     """
-    r: bytes = b""
+    r: List[int] = []
     z: bool = False
 
     for b in s:
@@ -102,12 +102,12 @@ def rle_decode(s: bytes) -> bytes:
             continue
 
         if z:
-            r += b"\x00" * b
+            r.extend((0,) * b)
             z = False
         else:
-            r += bytes([b])
+            r.append(b)
 
-    return r
+    return bytes(r)
 
 
 class FileType(IntEnum):

--- a/pyrogram/file_id.py
+++ b/pyrogram/file_id.py
@@ -88,10 +88,10 @@ def rle_decode(s: bytes) -> bytes:
 
     Parameters:
         s (``bytes``):
-            Bytes to encode
+            Bytes to decode
 
     Returns:
-        ``bytes``: The encoded bytes
+        ``bytes``: The decoded bytes
     """
     r: bytes = b""
     z: bool = False


### PR DESCRIPTION
in accordance with my tests (https://gist.github.com/andrew-ld/72f8ac8c41330a47c99a9f79958625eb), using a list and only at the end converting it in bytes is more efficient because bytes is an immutable instance.

```
testing sample 1
old 7.225026909000007
new 3.8671077140002126

testing sample 2
old 6.551758901000085
new 3.8057729349998226

testing sample 3
old 11.08116247199996
new 5.3508748690001084

testing sample 4
old 10.761553993000234
new 5.434736396000062

```
