### PR TITLE
Added support for Channel Comments

### DIFF
--- a/pyrogram/types/messages_and_media/__init__.py
+++ b/pyrogram/types/messages_and_media/__init__.py
@@ -25,6 +25,7 @@ from .game import Game
 from .location import Location
 from .message import Message
 from .message_entity import MessageEntity
+from .message_replies import MessageReplies
 from .photo import Photo
 from .poll import Poll
 from .poll_option import PollOption
@@ -41,5 +42,5 @@ from .reaction import Reaction
 __all__ = [
     "Animation", "Audio", "Contact", "Document", "Game", "Location", "Message", "MessageEntity", "Photo", "Thumbnail",
     "StrippedThumbnail", "Poll", "PollOption", "Sticker", "Venue", "Video", "VideoNote", "Voice", "WebPage", "Dice",
-    "Reaction"
+    "Reaction", "MessageReplies"
 ]

--- a/pyrogram/types/messages_and_media/message.py
+++ b/pyrogram/types/messages_and_media/message.py
@@ -801,6 +801,7 @@ class Message(Object, Update):
                 outgoing=message.out,
                 reply_markup=reply_markup,
                 reactions=reactions,
+                replies=message.replies,
                 client=client
             )
 

--- a/pyrogram/types/messages_and_media/message.py
+++ b/pyrogram/types/messages_and_media/message.py
@@ -373,7 +373,8 @@ class Message(Object, Update):
             "types.ReplyKeyboardRemove",
             "types.ForceReply"
         ] = None,
-        reactions: List["types.Reaction"] = None
+        reactions: List["types.Reaction"] = None,
+        replies: "types.MessageReplies" = None,
     ):
         super().__init__(client)
 
@@ -443,6 +444,7 @@ class Message(Object, Update):
         self.voice_chat_ended = voice_chat_ended
         self.voice_chat_members_invited = voice_chat_members_invited
         self.reactions = reactions
+        self.replies = replies
 
     @staticmethod
     async def _parse(

--- a/pyrogram/types/messages_and_media/message_replies.py
+++ b/pyrogram/types/messages_and_media/message_replies.py
@@ -1,0 +1,71 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
+from typing import List, Union
+
+import pyrogram
+from pyrogram import raw
+from ..object import Object
+
+
+class MessageReplies(Object):
+    """
+    Info about the comment section of a channel post, or a simple message thread.
+
+    Parameters:
+        replies (int 32-bit) – Contains the total number of replies in this thread or comment section.
+
+        replies_pts (int 32-bit) – PTS of the message that started this thread.
+
+        comments (bool, optional) – Whether this constructor contains information about the comment section of a channel post, or a simple message thread.
+
+        recent_repliers (List of Peer, optional) – For channel post comments, contains information about the last few comment posters for a specific thread, to show a small list of commenter profile pictures in client previews.
+
+        channel_id (int 64-bit, optional) – For channel post comments, contains the ID of the associated discussion supergroup.
+
+        max_id (int 32-bit, optional) – ID of the latest message in this thread or comment section.
+
+        read_max_id (int 32-bit, optional) – Contains the ID of the latest read message in this thread or comment section.
+
+
+    """
+
+    def __init__(self, *, client: "pyrogram.Client" = None, replies: int, replies_pts: int,
+                 comments: bool = None, recent_repliers: List[raw.types.PeerChannel] = None,
+                 channel_id: int = None, max_id: int = None, read_max_id: int = None):
+        super().__init__(client)
+
+        self.replies = replies
+        self.replies_pts = replies_pts
+        self.comments = comments
+        self.recent_repliers = recent_repliers
+        self.channel_id = channel_id
+        self.max_id = max_id
+        self.read_max_id = read_max_id
+
+    @staticmethod
+    def _parse(client, message_replies: "raw.types.MessageReplies") -> "MessageReplies":
+        return MessageReplies(
+            replies=message_replies.replies,
+            replies_pts=message_replies.replies_pts,
+            comments=message_replies.comments,
+            recent_repliers=message_replies.recent_repliers,
+            channel_id=message_replies.channel_id,
+            max_id=message_replies.max_id,
+            read_max_id=message_replies.read_max_id,
+            client=client
+        )

--- a/pyrogram/types/messages_and_media/message_replies.py
+++ b/pyrogram/types/messages_and_media/message_replies.py
@@ -27,21 +27,22 @@ class MessageReplies(Object):
     Info about the comment section of a channel post, or a simple message thread.
 
     Parameters:
-        replies (int 32-bit) – Contains the total number of replies in this thread or comment section.
-
-        replies_pts (int 32-bit) – PTS of the message that started this thread.
-
-        comments (bool, optional) – Whether this constructor contains information about the comment section of a channel post, or a simple message thread.
-
-        recent_repliers (List of Peer, optional) – For channel post comments, contains information about the last few comment posters for a specific thread, to show a small list of commenter profile pictures in client previews.
-
-        channel_id (int 64-bit, optional) – For channel post comments, contains the ID of the associated discussion supergroup.
-
-        max_id (int 32-bit, optional) – ID of the latest message in this thread or comment section.
-
-        read_max_id (int 32-bit, optional) – Contains the ID of the latest read message in this thread or comment section.
-
-
+        replies (``int``):
+            Contains the total number of replies in this thread or comment section.
+        replies_pts (``int``):
+            PTS of the message that started this thread.
+        comments (``bool``, *optional*):
+            Whether this constructor contains information about the comment section of a channel post,
+            or a simple message thread.
+        recent_repliers (``List[:obj:`pyrogram.types.Peer`]``, *optional*):
+            For channel post comments, contains information about the last few comment posters for a specific thread,
+            to show a small list of commenter profile pictures in client previews.
+        channel_id (``int``, *optional*):
+            For channel post comments, contains the ID of the associated discussion supergroup.
+        max_id (``int``, *optional*):
+            ID of the latest message in this thread or comment section.
+        read_max_id (``int``, *optional*):
+            Contains the ID of the latest read message in this thread or comment section.
     """
 
     def __init__(self, *, client: "pyrogram.Client" = None, replies: int, replies_pts: int,


### PR DESCRIPTION
Current version of pyrogram doesn't support [MessageReplies](https://docs.pyrogram.org/telegram/types/message-replies#pyrogram.raw.types.MessageReplies) filed in Message.
Provided support for it.