### PR TITLE
Add support for in-memory downloads

### DIFF
--- a/pyrogram/scaffold.py
+++ b/pyrogram/scaffold.py
@@ -201,3 +201,6 @@ class Scaffold:
 
     async def terminate(self, *args, **kwargs):
         pass
+
+    async def get_file(*args, **kwargs):
+        pass

--- a/pyrogram/types/messages_and_media/message.py
+++ b/pyrogram/types/messages_and_media/message.py
@@ -16,6 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+import io
 import logging
 from functools import partial
 from typing import List, Match, Union, BinaryIO, Optional
@@ -3350,10 +3351,11 @@ class Message(Object, Update):
 
     async def download(
         self,
-        file_name: str = "",
+        path_or_container: str | io.IOBase = "",
         block: bool = True,
         progress: callable = None,
-        progress_args: tuple = ()
+        progress_args: tuple = (),
+        file_name: str = "",
     ) -> str:
         """Bound method *download* of :obj:`~pyrogram.types.Message`.
 
@@ -3369,11 +3371,13 @@ class Message(Object, Update):
                 message.download()
 
         Parameters:
-            file_name (``str``, *optional*):
+            path_or_container (``str``, :class:`~io.IOBase`, *optional*):
                 A custom *file_name* to be used instead of the one provided by Telegram.
                 By default, all files are downloaded in the *downloads* folder in your working directory.
                 You can also specify a path for downloading files in a custom location: paths that end with "/"
                 are considered directories. All non-existent folders will be created automatically.
+
+                If subclass of io.IOBase container is provided, file instead will be downloaded to that container.
 
             block (``bool``, *optional*):
                 Blocks the code execution until the file has been downloaded.
@@ -3389,6 +3393,9 @@ class Message(Object, Update):
                 Extra custom arguments for the progress callback function.
                 You can pass anything you need to be available in the progress callback scope; for example, a Message
                 object or a Client instance in order to edit the message with the updated progress status.
+
+            file_name (``str``, *optional*):
+                Deprecated name of ``path_or_container`` argument
 
         Other Parameters:
             current (``int``):
@@ -3410,10 +3417,11 @@ class Message(Object, Update):
         """
         return await self._client.download_media(
             message=self,
-            file_name=file_name,
+            path_or_container=path_or_container,
             block=block,
             progress=progress,
             progress_args=progress_args,
+            **({'file_name': file_name} if file_name != "" else {}),
         )
 
     async def vote(


### PR DESCRIPTION
Closes #284

This PR aims to add support for in-memory downloads with as little changes as possible while maintaining backwards compatibility.

- `file_name` parameter replaced with `path_or_container`, which is backwards compatible
- `file_name` name is still accessible, but deprecated.
- docs changed accordingly

These changes have not been tested (CI should pass though)