### PR TITLE
fix: inline query results typing

### DIFF
--- a/pyrogram/methods/bots/answer_inline_query.py
+++ b/pyrogram/methods/bots/answer_inline_query.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import List
+from typing import Iterable
 
 from pyrogram import raw
 from pyrogram import types
@@ -27,7 +27,7 @@ class AnswerInlineQuery(Scaffold):
     async def answer_inline_query(
         self,
         inline_query_id: str,
-        results: List["types.InlineQueryResult"],
+        results: Iterable["types.InlineQueryResult"],
         cache_time: int = 300,
         is_gallery: bool = False,
         is_personal: bool = False,


### PR DESCRIPTION


Mypy was complaining since List is considered invariant and I was trying to pass a list of `InlineQueryResultArticle` and it was expecting a list of `InlineQueryResult`.

```python
    results = [
        InlineQueryResultArticle(...),
    ]

    await inline_query.answer(results=results, cache_time=1)
```
[mypy docs about this issue](https://mypy.readthedocs.io/en/stable/common_issues.html#invariance-vs-covariance)

I'm using `Iterable` instead of `Sequence` since it has more flexibility and allows generators etc.