### PR TITLE
Allow Custom Storage Engines

### DIFF
--- a/pyrogram/client.py
+++ b/pyrogram/client.py
@@ -49,7 +49,7 @@ from pyrogram.errors import (
 from pyrogram.handlers.handler import Handler
 from pyrogram.methods import Methods
 from pyrogram.session import Auth, Session
-from pyrogram.storage import FileStorage, MemoryStorage
+from pyrogram.storage import Storage, FileStorage, MemoryStorage
 from pyrogram.types import User, TermsOfService
 from pyrogram.utils import ainput
 from .dispatcher import Dispatcher
@@ -113,6 +113,10 @@ class Client(Methods):
         session_string (``str``, *optional*):
             Pass a session string to load the session in-memory.
             Implies ``in_memory=True``.
+
+        session_storage_engine (:obj:`~pyrogram.storage.Storage`, *optional*):
+            Pass an instance of your own implementation of session storage engine.
+            Useful when you want to store your session in databases like Mongo, Redis, etc.
 
         in_memory (``bool``, *optional*):
             Pass True to start an in-memory session that will be discarded as soon as the client stops.
@@ -203,6 +207,7 @@ class Client(Methods):
         test_mode: bool = False,
         bot_token: str = None,
         session_string: str = None,
+        session_storage_engine: Storage = None,
         in_memory: bool = None,
         phone_number: str = None,
         phone_code: str = None,
@@ -247,6 +252,8 @@ class Client(Methods):
 
         if self.session_string:
             self.storage = MemoryStorage(self.name, self.session_string)
+        elif isinstance(session_storage_engine, Storage):
+            self.storage = session_storage_engine
         elif self.in_memory:
             self.storage = MemoryStorage(self.name)
         else:


### PR DESCRIPTION
In previous version of Pyrogram, `session_name` used to accept a str or [Storage](https://github.com/pyrogram/pyrogram/blob/master/pyrogram/storage/storage.py)  object, which enabled us to store sessions in databases other than the one's that are provided by default (FileStorage and MemoryStorage). I've been using my own implementation of storage engine to store session data in Mongo Database, but Pyrogram v2.0 is missing that feature.