### PR TITLE
Fix for Self-Destruct if file_id and ttl_seconds are passed

### DIFF
--- a/pyrogram/methods/messages/send_photo.py
+++ b/pyrogram/methods/messages/send_photo.py
@@ -155,7 +155,7 @@ class SendPhoto:
                         ttl_seconds=ttl_seconds
                     )
                 else:
-                    media = utils.get_input_media_from_file_id(photo, FileType.PHOTO)
+                    media = utils.get_input_media_from_file_id(photo, FileType.PHOTO, ttl_seconds=ttl_seconds)
             else:
                 file = await self.save_file(photo, progress=progress, progress_args=progress_args)
                 media = raw.types.InputMediaUploadedPhoto(

--- a/pyrogram/methods/messages/send_video.py
+++ b/pyrogram/methods/messages/send_video.py
@@ -200,7 +200,7 @@ class SendVideo:
                         ttl_seconds=ttl_seconds
                     )
                 else:
-                    media = utils.get_input_media_from_file_id(video, FileType.VIDEO)
+                    media = utils.get_input_media_from_file_id(video, FileType.VIDEO, ttl_seconds=ttl_seconds)
             else:
                 thumb = await self.save_file(thumb)
                 file = await self.save_file(video, progress=progress, progress_args=progress_args)

--- a/pyrogram/utils.py
+++ b/pyrogram/utils.py
@@ -42,7 +42,8 @@ async def ainput(prompt: str = "", *, hide: bool = False):
 
 def get_input_media_from_file_id(
     file_id: str,
-    expected_file_type: FileType = None
+    expected_file_type: FileType = None,
+    ttl_seconds: int = None
 ) -> Union["raw.types.InputMediaPhoto", "raw.types.InputMediaDocument"]:
     try:
         decoded = FileId.decode(file_id)
@@ -64,7 +65,8 @@ def get_input_media_from_file_id(
                 id=decoded.media_id,
                 access_hash=decoded.access_hash,
                 file_reference=decoded.file_reference
-            )
+            ),
+            ttl_seconds=ttl_seconds
         )
 
     if file_type in DOCUMENT_TYPES:
@@ -73,7 +75,8 @@ def get_input_media_from_file_id(
                 id=decoded.media_id,
                 access_hash=decoded.access_hash,
                 file_reference=decoded.file_reference
-            )
+            ),
+            ttl_seconds=ttl_seconds
         )
 
     raise ValueError(f"Unknown file id: {file_id}")


### PR DESCRIPTION
Fixes `case 1` of issue [#829](https://github.com/pyrogram/pyrogram/issues/829)