### PR TITLE
Fix write method missing in `pyrogram.raw.core.List`

### DIFF
--- a/pyrogram/raw/core/list.py
+++ b/pyrogram/raw/core/list.py
@@ -24,3 +24,10 @@ from .tl_object import TLObject
 class List(TList[Any], TLObject):
     def __repr__(self) -> str:
         return f"pyrogram.raw.core.List([{','.join(TLObject.__repr__(i) for i in self)}])"
+
+    def write(self, *args: Any) -> bytes:
+        from . import Int
+        return b"".join(
+            [Int(0x1CB5C415, False), Int(len(self), False)]
+            + [i.write() for i in self]
+        )


### PR DESCRIPTION
# Description

This is a temporary workaround for the method `pyrogram.raw.core.List`
The `write` method can be called by `RpcResult` and when the query is `GetDialogFilters` (Which the result is empty by default)
The error will be `TypeError: 'NoneType' does not support the buffer interface`

# Steps to reproduce

For error:
```python
b = BytesIO()
b.write(None)
```

What actually happened:
```python
# RpcResult > write()
b.write(self.result.write())  # Where self.result is a pyrogram.raw.core.List([])
```

When `pyrogram.raw.core.List.write` is called, it will call `TLObject.write`, but it's will return a `None` type since it's a empty function

---

The reason I opened this PR is to ask is there any other workaround, the code quality of this looks bad.