### PR TITLE
Add Websocket Transport support

### DIFF
--- a/pyrogram/connection/connection.py
+++ b/pyrogram/connection/connection.py
@@ -38,7 +38,7 @@ class Connection:
         5: WEBSOCKETAbridgedO
     }
 
-    def __init__(self, dc_id: int, test_mode: bool, ipv6: bool, proxy: dict, media: bool = False, mode: int = 5, websocket_endpoint: bool = True):
+    def __init__(self, dc_id: int, test_mode: bool, ipv6: bool, proxy: dict, media: bool = False, mode: int = 3, websocket_endpoint: bool = False):
         self.dc_id = dc_id
         self.test_mode = test_mode
         self.ipv6 = ipv6

--- a/pyrogram/connection/connection.py
+++ b/pyrogram/connection/connection.py
@@ -34,16 +34,17 @@ class Connection:
         1: TCPAbridged,
         2: TCPIntermediate,
         3: TCPAbridgedO,
-        4: TCPIntermediateO
+        4: TCPIntermediateO,
+        5: WEBSOCKETAbridgedO
     }
 
-    def __init__(self, dc_id: int, test_mode: bool, ipv6: bool, proxy: dict, media: bool = False, mode: int = 3):
+    def __init__(self, dc_id: int, test_mode: bool, ipv6: bool, proxy: dict, media: bool = False, mode: int = 5, websocket_endpoint: bool = True):
         self.dc_id = dc_id
         self.test_mode = test_mode
         self.ipv6 = ipv6
         self.proxy = proxy
         self.media = media
-        self.address = DataCenter(dc_id, test_mode, ipv6, media)
+        self.address = DataCenter(dc_id, test_mode, ipv6, media, websocket_endpoint)
         self.mode = self.MODES.get(mode, TCPAbridged)
 
         self.protocol = None  # type: TCP
@@ -51,9 +52,8 @@ class Connection:
     async def connect(self):
         for i in range(Connection.MAX_RETRIES):
             self.protocol = self.mode(self.ipv6, self.proxy)
-
             try:
-                log.info("Connecting...")
+                log.info(f"Connecting to {self.address}...")
                 await self.protocol.connect(self.address)
             except OSError as e:
                 log.warning(f"Unable to connect due to network issues: {e}")

--- a/pyrogram/connection/transport/websock/__init__.py
+++ b/pyrogram/connection/transport/websock/__init__.py
@@ -16,5 +16,5 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from .tcp import *
-from .websock import *
+from .websock import WEBSOCKET
+from .websocket_abridged_o import WEBSOCKETAbridgedO

--- a/pyrogram/connection/transport/websock/websock.py
+++ b/pyrogram/connection/transport/websock/websock.py
@@ -1,0 +1,119 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
+
+import asyncio
+import logging
+import websocket
+import sys
+import contextvars
+import functools
+from websocket._exceptions import WebSocketException
+from websocket._http import ProxyError,ProxyTimeoutError,ProxyConnectionError
+
+async def to_thread(func, /, *args, **kwargs):
+    loop = asyncio.get_running_loop()
+    ctx = contextvars.copy_context()
+    func_call = functools.partial(ctx.run, func, *args, **kwargs)
+    return await loop.run_in_executor(None, func_call)
+
+if sys.version_info.major == 3 and sys.version_info.minor < 9:
+    asyncio.to_thread = to_thread
+
+def extract_err_message(exception):
+    if exception.args:
+        return exception.args[0]
+    else:
+        return '' 
+
+log = logging.getLogger(__name__)
+
+class WEBSOCKET:
+    TIMEOUT = 10
+
+    def __init__(self, ipv6: bool, proxy: dict):
+        self.socket = None
+
+        self.lock = asyncio.Lock()
+        self.loop = asyncio.get_event_loop()
+
+        websocket.setdefaulttimeout(WEBSOCKET.TIMEOUT)
+        self.socket = websocket.WebSocket()
+        if proxy:
+            self.proxy_type=proxy.get("scheme")
+            self.http_proxy_host=proxy.get("hostname")
+            self.http_proxy_port=proxy.get("port", None)
+            log.info(f"Using proxy {self.http_proxy_host}")
+        else:
+            self.proxy_type=""
+            self.http_proxy_host=""
+            self.http_proxy_port=""
+
+        self.data_buffer=b''
+
+    async def connect(self, address: tuple):
+        try:
+            scheme = "wss" if address[1]==443 else "ws"
+            if self.proxy_type:
+                await asyncio.to_thread(self.socket.connect,f"{scheme}://{address[0]}:{address[1]}/apiws", http_proxy_host=self.http_proxy_host, http_proxy_port=self.http_proxy_port, proxy_type=self.proxy_type, timeout=WEBSOCKET.TIMEOUT)
+            else:
+                await asyncio.to_thread(self.socket.connect,f"{scheme}://{address[0]}:{address[1]}/apiws",timeout=WEBSOCKET.TIMEOUT)
+        except (WebSocketException,ProxyError,ProxyTimeoutError,ProxyConnectionError) as e:
+            raise OSError(extract_err_message(e))
+        except Exception as e:
+            log.error(f'{type(e).__name__}: {e}')
+            raise e
+
+    def close(self):
+        try:
+            self.socket.close()
+        except (WebSocketException,ProxyError,ProxyTimeoutError,ProxyConnectionError) as e:
+            raise OSError(extract_err_message(e))
+        except Exception as e:
+            log.error(f'{type(e).__name__}: {e}')
+            raise e
+
+    async def send(self, data: bytes):
+        async with self.lock:
+            try:
+                await asyncio.to_thread(self.socket.send_binary, data)
+            except (WebSocketException,ProxyError,ProxyTimeoutError,ProxyConnectionError) as e:
+                raise OSError(extract_err_message(e))
+            except Exception as e:
+                log.error(f'{type(e).__name__}: {e}')
+                raise e
+
+    async def recv(self, length: int = 0):
+        data = self.data_buffer + b""
+
+        while len(data) < length:
+            try:
+                chunk = await asyncio.to_thread(self.socket.recv)
+            except (WebSocketException,ProxyError,ProxyTimeoutError,ProxyConnectionError) as e:
+                log.error(f'{type(e).__name__}: {e}')
+                return None
+            except Exception as e:
+                raise e
+            else:
+                if chunk:
+                    data += chunk
+                else:
+                    return None
+
+        self.data_buffer = data[length:]+b''
+        return data[:length]
+

--- a/pyrogram/connection/transport/websock/websock.py
+++ b/pyrogram/connection/transport/websock/websock.py
@@ -83,7 +83,7 @@ class WEBSOCKET:
             else:
                 await asyncio.to_thread(self.socket.connect,f"{scheme}://{address[0]}:{address[1]}/apiws",timeout=WEBSOCKET.TIMEOUT)
             self.isconnected=True
-            asyncio.create_task(pingtask())
+            asyncio.create_task(self.pingtask())
         except (WebSocketException,ProxyError,ProxyTimeoutError,ProxyConnectionError) as e:
             raise OSError(extract_err_message(e))
         except Exception as e:

--- a/pyrogram/connection/transport/websock/websock.py
+++ b/pyrogram/connection/transport/websock/websock.py
@@ -83,7 +83,7 @@ class WEBSOCKET:
             else:
                 await asyncio.to_thread(self.socket.connect,f"{scheme}://{address[0]}:{address[1]}/apiws",timeout=WEBSOCKET.TIMEOUT)
             self.isconnected=True
-            asyncio.create_task(self.pingtask())
+            #asyncio.create_task(self.pingtask())
         except (WebSocketException,ProxyError,ProxyTimeoutError,ProxyConnectionError) as e:
             raise OSError(extract_err_message(e))
         except Exception as e:

--- a/pyrogram/connection/transport/websock/websocket_abridged_o.py
+++ b/pyrogram/connection/transport/websock/websocket_abridged_o.py
@@ -1,0 +1,86 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+import os
+from typing import Optional
+
+import pyrogram
+from pyrogram.crypto import aes
+from .websock import WEBSOCKET 
+
+log = logging.getLogger(__name__)
+
+
+class WEBSOCKETAbridgedO(WEBSOCKET):
+    RESERVED = (b"HEAD", b"POST", b"GET ", b"OPTI", b"\xee" * 4)
+
+    def __init__(self, ipv6: bool, proxy: dict):
+        super().__init__(ipv6, proxy)
+
+        self.encrypt = None
+        self.decrypt = None
+
+    async def connect(self, address: tuple):
+        await super().connect(address)
+
+        while True:
+            nonce = bytearray(os.urandom(64))
+
+            if nonce[0] != b"\xef" and nonce[:4] not in self.RESERVED and nonce[4:4] != b"\x00" * 4:
+                nonce[56] = nonce[57] = nonce[58] = nonce[59] = 0xef
+                break
+
+        temp = bytearray(nonce[55:7:-1])
+
+        self.encrypt = (nonce[8:40], nonce[40:56], bytearray(1))
+        self.decrypt = (temp[0:32], temp[32:48], bytearray(1))
+
+        nonce[56:64] = aes.ctr256_encrypt(nonce, *self.encrypt)[56:64]
+
+        await super().send(nonce)
+
+    async def send(self, data: bytes, *args):
+        length = len(data) // 4
+        data = (bytes([length]) if length <= 126 else b"\x7f" + length.to_bytes(3, "little")) + data
+        payload = await self.loop.run_in_executor(pyrogram.crypto_executor, aes.ctr256_encrypt, data, *self.encrypt)
+
+        await super().send(payload)
+
+    async def recv(self, length: int = 0) -> Optional[bytes]:
+        length = await super().recv(1)
+
+        if length is None:
+            return None
+
+        length = aes.ctr256_decrypt(length, *self.decrypt)
+
+        if length == b"\x7f":
+            length = await super().recv(3)
+
+            if length is None:
+                return None
+
+            length = aes.ctr256_decrypt(length, *self.decrypt)
+
+        data = await super().recv(int.from_bytes(length, "little") * 4)
+
+        if data is None:
+            return None
+
+        return await self.loop.run_in_executor(pyrogram.crypto_executor, aes.ctr256_decrypt, data, *self.decrypt)

--- a/pyrogram/session/internals/data_center.py
+++ b/pyrogram/session/internals/data_center.py
@@ -58,8 +58,18 @@ class DataCenter:
         4: "2001:067c:04e8:f004:0000:0000:0000:000b"
     }
 
-    def __new__(cls, dc_id: int, test_mode: bool, ipv6: bool, media: bool) -> Tuple[str, int]:
+    WEBSOCKET = {
+        1: "pluto.web.telegram.org",
+        2: "venus.web.telegram.org",
+        3: "aurora.web.telegram.org",
+        4: "vesta.web.telegram.org",
+        5: "flora.web.telegram.org"
+    }
+
+    def __new__(cls, dc_id: int, test_mode: bool, ipv6: bool, media: bool, websocket: bool) -> Tuple[str, int]:
         if test_mode:
+            if websocket:
+                return cls.WEBSOCKET[dc_id], 80
             if ipv6:
                 ip = cls.TEST_IPV6[dc_id]
             else:
@@ -67,6 +77,8 @@ class DataCenter:
 
             return ip, 80
         else:
+            if websocket:
+                return cls.WEBSOCKET[dc_id], 443
             if ipv6:
                 if media:
                     ip = cls.PROD_IPV6_MEDIA.get(dc_id, cls.PROD_IPV6[dc_id])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 pyaes==1.6.1
 pysocks==1.7.1
+websocket-client==1.3.2
+python_socks==2.0.3


### PR DESCRIPTION
I added a websocket transport. It works also with http/socks proxy.
My use case is running on https://www.pythonanywhere.com/ where free users are restricted to whitelisted http/s connections and only via a http proxy. The telegram dc url endpoints are whitelisted but not the tcp ones.
I guess there are more use cases like this where a tcp transport is blocked and a websocket is not. 