### PR TITLE
Correct FAQ answer.

### DIFF
--- a/docs/source/faq/how-to-avoid-flood-waits.rst
+++ b/docs/source/faq/how-to-avoid-flood-waits.rst
@@ -9,7 +9,7 @@ The following shows how to catch the exception in your code and wait the require
 
 .. code-block:: python
 
-  import time
+  import asyncio
   from pyrogram.errors import FloodWait
 
   ...


### PR DESCRIPTION
*Link of incorrect:* [How to avoid Flood Waits?](https://docs.pyrogram.org/faq/how-to-avoid-flood-waits#how-to-avoid-flood-waits:~:text=the%20required%20seconds.-,import%20time,-from%20pyrogram.errors)