### PR TITLE
Fix missing type hints and corrections

### DIFF
--- a/pyrogram/methods/bots/get_inline_bot_results.py
+++ b/pyrogram/methods/bots/get_inline_bot_results.py
@@ -31,7 +31,7 @@ class GetInlineBotResults:
         offset: str = "",
         latitude: float = None,
         longitude: float = None
-    ) -> raw.types.messages.BotResults:
+    ) -> "raw.types.messages.BotResults":
         """Get bot results via inline queries.
         You can then send a result using :meth:`~pyrogram.Client.send_inline_bot_result`
 

--- a/pyrogram/methods/bots/get_inline_bot_results.py
+++ b/pyrogram/methods/bots/get_inline_bot_results.py
@@ -31,7 +31,7 @@ class GetInlineBotResults:
         offset: str = "",
         latitude: float = None,
         longitude: float = None
-    ):
+    ) -> raw.types.messages.BotResults:
         """Get bot results via inline queries.
         You can then send a result using :meth:`~pyrogram.Client.send_inline_bot_result`
 
@@ -56,7 +56,7 @@ class GetInlineBotResults:
                 Useful for location-based results only.
 
         Returns:
-            :obj:`BotResults <pyrogram.api.types.messages.BotResults>`: On Success.
+            :obj:`BotResults <pyrogram.raw.types.messages.BotResults>`: On Success.
 
         Raises:
             TimeoutError: In case the bot fails to answer within 10 seconds.

--- a/pyrogram/methods/bots/send_inline_bot_result.py
+++ b/pyrogram/methods/bots/send_inline_bot_result.py
@@ -30,7 +30,7 @@ class SendInlineBotResult:
         query_id: int,
         result_id: str,
         disable_notification: bool = None,
-        reply_to_message_id: int = None,
+        reply_to_message_id: int = None
     ) -> "types.Message":
         """Send an inline bot result.
         Bot results can be retrieved using :meth:`~pyrogram.Client.get_inline_bot_results`


### PR DESCRIPTION
* added missing type hints to get_inline_bot_results and send_inline_bot_result
* send_inline_bot_result is returns `pyrogram.types.Message` now