### PR TITLE
Fix public chat join request miss invite link

### DIFF
--- a/pyrogram/types/user_and_chats/chat_invite_link.py
+++ b/pyrogram/types/user_and_chats/chat_invite_link.py
@@ -104,11 +104,12 @@ class ChatInviteLink(Object):
         invite: "raw.base.ExportedChatInvite",
         users: Dict[int, "raw.types.User"] = None
     ) -> "ChatInviteLink":
-        creator = (
-            types.User._parse(client, users[invite.admin_id])
-            if users is not None
-            else None
-        )
+        if users is not None:
+            if not hasattr(invite, "admin_id"):
+                return None
+            creator = types.User._parse(client, users[invite.admin_id])
+        else:
+            creator = None
 
         return ChatInviteLink(
             invite_link=invite.link,


### PR DESCRIPTION
public chat join request will raise `invite` miss `admin_id` attr

fixes: #1037 