### PR TITLE
Fix inline quirks and mistakes

### DIFF
--- a/pyrogram/methods/messages/edit_inline_media.py
+++ b/pyrogram/methods/messages/edit_inline_media.py
@@ -18,16 +18,20 @@
 
 import os
 import re
+import asyncio
 
 import pyrogram
 from pyrogram import raw
 from pyrogram import types
 from pyrogram import utils
+from pyrogram.errors import RPCError, MediaEmpty
 from pyrogram.file_id import FileType
 from .inline_session import get_session
 
 
 class EditInlineMedia:
+    MAX_RETRIES = 3
+
     async def edit_inline_media(
         self: "pyrogram.Client",
         inline_message_id: str,
@@ -147,7 +151,8 @@ class EditInlineMedia:
                             file_name=os.path.basename(media.media)
                         ),
                         raw.types.DocumentAttributeAnimated()
-                    ]
+                    ],
+                    nosound_video=True
                 )
             elif re.match("^https?://", media.media):
                 media = raw.types.InputMediaDocumentExternal(
@@ -165,7 +170,8 @@ class EditInlineMedia:
                         raw.types.DocumentAttributeFilename(
                             file_name=os.path.basename(media.media)
                         )
-                    ]
+                    ],
+                    force_file=True
                 )
             elif re.match("^https?://", media.media):
                 media = raw.types.InputMediaDocumentExternal(
@@ -179,12 +185,34 @@ class EditInlineMedia:
 
         session = await get_session(self, dc_id)
 
-        return await session.invoke(
-            raw.functions.messages.EditInlineBotMessage(
-                id=unpacked,
-                media=media,
-                reply_markup=await reply_markup.write(self) if reply_markup else None,
-                **await self.parser.parse(caption, parse_mode)
-            ),
-            sleep_threshold=self.sleep_threshold
+        actual_media = await self.invoke(
+            raw.functions.messages.UploadMedia(
+                peer=raw.types.InputPeerSelf(),
+                media=media
+            )
         )
+
+        for i in range(self.MAX_RETRIES):
+            try:
+                return await session.invoke(
+                    raw.functions.messages.EditInlineBotMessage(
+                        id=unpacked,
+                        media=raw.types.InputMediaDocument(
+                            id=raw.types.InputDocument(
+                                id=actual_media.document.id,
+                                access_hash=actual_media.document.access_hash,
+                                file_reference=actual_media.document.file_reference
+                            )
+                        ),
+                        reply_markup=await reply_markup.write(self) if reply_markup else None,
+                        **await self.parser.parse(caption, parse_mode)
+                    ),
+                    sleep_threshold=self.sleep_threshold
+                )
+            except RPCError as e:
+                if i == self.MAX_RETRIES - 1:
+                    raise
+
+                if isinstance(e, MediaEmpty):
+                    # Must wait due to a server race condition
+                    await asyncio.sleep(1)

--- a/pyrogram/methods/messages/inline_session.py
+++ b/pyrogram/methods/messages/inline_session.py
@@ -33,8 +33,8 @@ async def get_session(client: "pyrogram.Client", dc_id: int):
 
         session = client.media_sessions[dc_id] = Session(
             client, dc_id,
-            await Auth(client, dc_id, False).create(),
-            False, is_media=True
+            await Auth(client, dc_id, await client.storage.test_mode()).create(),
+            await client.storage.test_mode(), is_media=True
         )
 
         await session.start()


### PR DESCRIPTION
Inline mode done right:
- Fixed `FilePartMissing: Telegram says: [400 FILE_PART_X_MISSING] - Part 0 of the file is missing from storage (caused by "messages.EditInlineBotMessage")` when editing a media in a chat which DC id is different by the bot's one
- `inline_session.get_session` always assumed to be in production server, changed it to `client.storage.test_mode()`
- `force_file=True` for `InputMediaDocument`
- `nosound_video=True` for `InputMediaAnimation`
- Implemented retries due to a server race condition which might lead to `MEDIA_EMPTY`