### PR TITLE
Filter out empty entities internally

### DIFF
--- a/pyrogram/parser/html.py
+++ b/pyrogram/parser/html.py
@@ -140,6 +140,8 @@ class HTML:
 
             entities.append(entity)
 
+        entities = list(filter(lambda x: x.length > 0, entities))
+
         return {
             "message": utils.remove_surrogates(parser.text),
             "entities": sorted(entities, key=lambda e: e.offset)
@@ -156,13 +158,21 @@ class HTML:
             start = entity.offset
             end = start + entity.length
 
-            if entity_type in (MessageEntityType.BOLD, MessageEntityType.ITALIC, MessageEntityType.UNDERLINE,
-                               MessageEntityType.STRIKETHROUGH):
+            if entity_type in (
+                MessageEntityType.BOLD,
+                MessageEntityType.ITALIC,
+                MessageEntityType.UNDERLINE,
+                MessageEntityType.STRIKETHROUGH,
+            ):
                 name = entity_type.name[0].lower()
                 start_tag = f"<{name}>"
                 end_tag = f"</{name}>"
-            elif entity_type in (MessageEntityType.CODE, MessageEntityType.PRE, MessageEntityType.BLOCKQUOTE,
-                                 MessageEntityType.SPOILER):
+            elif entity_type in (
+                MessageEntityType.CODE,
+                MessageEntityType.PRE,
+                MessageEntityType.BLOCKQUOTE,
+                MessageEntityType.SPOILER,
+            ):
                 name = entity_type.name.lower()
                 start_tag = f"<{name}>"
                 end_tag = f"</{name}>"

--- a/pyrogram/parser/html.py
+++ b/pyrogram/parser/html.py
@@ -140,6 +140,7 @@ class HTML:
 
             entities.append(entity)
 
+        # Remove zero-length entities
         entities = list(filter(lambda x: x.length > 0, entities))
 
         return {

--- a/pyrogram/utils.py
+++ b/pyrogram/utils.py
@@ -142,9 +142,10 @@ def parse_deleted_messages(client, update) -> List["types.Message"]:
             types.Message(
                 id=message,
                 chat=types.Chat(
-                    id=get_channel_id(channel_id), type=enums.ChatType.CHANNEL, client=client
-                )
-                if channel_id is not None
+                    id=get_channel_id(channel_id),
+                    type=enums.ChatType.CHANNEL,
+                    client=client
+                ) if channel_id is not None
                 else None,
                 client=client
             )

--- a/pyrogram/utils.py
+++ b/pyrogram/utils.py
@@ -344,7 +344,7 @@ async def parse_text_entities(
 
     return {
         "message": text,
-        "entities": entities
+        "entities": list(filter(lambda x:x.length > 0, entities))
     }
 
 

--- a/pyrogram/utils.py
+++ b/pyrogram/utils.py
@@ -145,7 +145,7 @@ def parse_deleted_messages(client, update) -> List["types.Message"]:
                     id=get_channel_id(channel_id),
                     type=enums.ChatType.CHANNEL,
                     client=client
-                ) if channel_id is not None,
+                ) if channel_id is not None else None,
                 client=client
             )
         )

--- a/pyrogram/utils.py
+++ b/pyrogram/utils.py
@@ -85,7 +85,9 @@ def get_input_media_from_file_id(
 
 
 async def parse_messages(
-    client, messages: "raw.types.messages.Messages", replies: int = 1
+    client,
+    messages: "raw.types.messages.Messages",
+    replies: int = 1
 ) -> List["types.Message"]:
     users = {i.id: i for i in messages.users}
     chats = {i.id: i for i in messages.chats}

--- a/pyrogram/utils.py
+++ b/pyrogram/utils.py
@@ -48,8 +48,10 @@ def get_input_media_from_file_id(
     try:
         decoded = FileId.decode(file_id)
     except Exception:
-        raise ValueError(f'Failed to decode "{file_id}". The value does not represent an existing local file, '
-                         f'HTTP URL, or valid file id.')
+        raise ValueError(
+            f'Failed to decode "{file_id}". The value does not represent an existing local file, '
+            f"HTTP URL, or valid file id."
+        )
 
     file_type = decoded.file_type
 
@@ -82,7 +84,9 @@ def get_input_media_from_file_id(
     raise ValueError(f"Unknown file id: {file_id}")
 
 
-async def parse_messages(client, messages: "raw.types.messages.Messages", replies: int = 1) -> List["types.Message"]:
+async def parse_messages(
+    client, messages: "raw.types.messages.Messages", replies: int = 1
+) -> List["types.Message"]:
     users = {i.id: i for i in messages.users}
     chats = {i.id: i for i in messages.chats}
 
@@ -138,10 +142,10 @@ def parse_deleted_messages(client, update) -> List["types.Message"]:
             types.Message(
                 id=message,
                 chat=types.Chat(
-                    id=get_channel_id(channel_id),
-                    type=enums.ChatType.CHANNEL,
-                    client=client
-                ) if channel_id is not None else None,
+                    id=get_channel_id(channel_id), type=enums.ChatType.CHANNEL, client=client
+                )
+                if channel_id is not None
+                else None,
                 client=client
             )
         )
@@ -260,8 +264,9 @@ def xor(a: bytes, b: bytes) -> bytes:
     return bytes(i ^ j for i, j in zip(a, b))
 
 
-def compute_password_hash(algo: raw.types.PasswordKdfAlgoSHA256SHA256PBKDF2HMACSHA512iter100000SHA256ModPow,
-                          password: str) -> bytes:
+def compute_password_hash(
+    algo: raw.types.PasswordKdfAlgoSHA256SHA256PBKDF2HMACSHA512iter100000SHA256ModPow, password: str
+) -> bytes:
     hash1 = sha256(algo.salt1 + password.encode() + algo.salt1)
     hash2 = sha256(algo.salt2 + hash1 + algo.salt2)
     hash3 = hashlib.pbkdf2_hmac("sha512", hash2, algo.salt1, 100000)
@@ -344,7 +349,7 @@ async def parse_text_entities(
 
     return {
         "message": text,
-        "entities": list(filter(lambda x:x.length > 0, entities))
+        "entities": entities
     }
 
 

--- a/pyrogram/utils.py
+++ b/pyrogram/utils.py
@@ -145,8 +145,7 @@ def parse_deleted_messages(client, update) -> List["types.Message"]:
                     id=get_channel_id(channel_id),
                     type=enums.ChatType.CHANNEL,
                     client=client
-                ) if channel_id is not None
-                else None,
+                ) if channel_id is not None,
                 client=client
             )
         )

--- a/pyrogram/utils.py
+++ b/pyrogram/utils.py
@@ -267,7 +267,8 @@ def xor(a: bytes, b: bytes) -> bytes:
 
 
 def compute_password_hash(
-    algo: raw.types.PasswordKdfAlgoSHA256SHA256PBKDF2HMACSHA512iter100000SHA256ModPow, password: str
+    algo: raw.types.PasswordKdfAlgoSHA256SHA256PBKDF2HMACSHA512iter100000SHA256ModPow,
+    password: str
 ) -> bytes:
     hash1 = sha256(algo.salt1 + password.encode() + algo.salt1)
     hash2 = sha256(algo.salt2 + hash1 + algo.salt2)
@@ -277,7 +278,10 @@ def compute_password_hash(
 
 
 # noinspection PyPep8Naming
-def compute_password_check(r: raw.types.account.Password, password: str) -> raw.types.InputCheckPasswordSRP:
+def compute_password_check(
+    r: raw.types.account.Password,
+    password: str
+) -> raw.types.InputCheckPasswordSRP:
     algo = r.current_algo
 
     p_bytes = algo.p


### PR DESCRIPTION
I guess it's fine to handle empty entities internally to avoid ENTITY_BOUNDS_INVALID , so the client won't send the empty entities