### PR TITLE
Store "me" user object before starting dispatcher

### DIFF
--- a/pyrogram/methods/auth/initialize.py
+++ b/pyrogram/methods/auth/initialize.py
@@ -44,8 +44,8 @@ class Initialize:
 
         self.load_plugins()
 
-        await self.dispatcher.start()
-
         self.me = await self.get_me()
+
+        await self.dispatcher.start()
 
         self.is_initialized = True


### PR DESCRIPTION
To avoid AttributeError we should store the "me" user object before starting dispatcher.

Error Logs:
```
06:34:23 PM - 229 - pyrogram.dispatcher - dispatcher - ERROR - 'NoneType' object has no attribute 'username'        
Traceback (most recent call last):
  File "d:\Python Projects\Assistant\venv\lib\site-packages\pyrogram\dispatcher.py", line 226, in handler_worker
    if await handler.check(self.client, parsed_update):
  File "d:\Python Projects\Assistant\venv\lib\site-packages\pyrogram\handlers\handler.py", line 35, in check    
    return await self.filters(client, update)
  File "d:\Python Projects\Assistant\venv\lib\site-packages\pyrogram\filters.py", line 66, in __call__
    x = await self.base(client, update)
  File "d:\Python Projects\Assistant\venv\lib\site-packages\pyrogram\filters.py", line 760, in func
    username = client.me.username or ""
AttributeError: 'NoneType' object has no attribute 'username'
```