### PR TITLE
Fixed and improved edit_inline_media once again

### DIFF
--- a/pyrogram/methods/messages/edit_inline_media.py
+++ b/pyrogram/methods/messages/edit_inline_media.py
@@ -18,6 +18,7 @@
 
 import os
 import re
+import io
 import asyncio
 
 import pyrogram
@@ -76,21 +77,41 @@ class EditInlineMedia:
         caption = media.caption
         parse_mode = media.parse_mode
 
-        if isinstance(media, types.InputMediaPhoto):
-            if os.path.isfile(media.media):
+        is_photo = isinstance(media, types.InputMediaPhoto)
+
+        is_bytes_io = isinstance(media.media, io.BytesIO)
+        is_uploaded_file = is_bytes_io or os.path.isfile(media.media)
+
+        is_external_url = not is_uploaded_file and re.match("^https?://", media.media)
+
+        if is_bytes_io and not hasattr(media.media, "name"):
+            media.media.name = "media"
+
+        if is_uploaded_file:
+            filename_attribute = [
+                raw.types.DocumentAttributeFilename(
+                    file_name=media.media.name if is_bytes_io else os.path.basename(media.media)
+                )
+            ]
+        else:
+            filename_attribute = []
+
+
+        if is_photo:
+            if is_uploaded_file:
                 media = raw.types.InputMediaUploadedPhoto(
                     file=await self.save_file(media.media)
                 )
-            elif re.match("^https?://", media.media):
+            elif is_external_url:
                 media = raw.types.InputMediaPhotoExternal(
                     url=media.media
                 )
             else:
                 media = utils.get_input_media_from_file_id(media.media, FileType.PHOTO)
         elif isinstance(media, types.InputMediaVideo):
-            if os.path.isfile(media.media):
+            if is_uploaded_file:
                 media = raw.types.InputMediaUploadedDocument(
-                    mime_type=self.guess_mime_type(media.media) or "video/mp4",
+                    mime_type=(None if is_bytes_io else self.guess_mime_type(media.media)) or "video/mp4",
                     thumb=await self.save_file(media.thumb),
                     file=await self.save_file(media.media),
                     attributes=[
@@ -99,22 +120,19 @@ class EditInlineMedia:
                             duration=media.duration,
                             w=media.width,
                             h=media.height
-                        ),
-                        raw.types.DocumentAttributeFilename(
-                            file_name=os.path.basename(media.media)
                         )
-                    ]
+                    ] + filename_attribute
                 )
-            elif re.match("^https?://", media.media):
+            elif is_external_url:
                 media = raw.types.InputMediaDocumentExternal(
                     url=media.media
                 )
             else:
                 media = utils.get_input_media_from_file_id(media.media, FileType.VIDEO)
         elif isinstance(media, types.InputMediaAudio):
-            if os.path.isfile(media.media):
+            if is_uploaded_file:
                 media = raw.types.InputMediaUploadedDocument(
-                    mime_type=self.guess_mime_type(media.media) or "audio/mpeg",
+                    mime_type=(None if is_bytes_io else self.guess_mime_type(media.media)) or "audio/mpeg",
                     thumb=await self.save_file(media.thumb),
                     file=await self.save_file(media.media),
                     attributes=[
@@ -122,22 +140,19 @@ class EditInlineMedia:
                             duration=media.duration,
                             performer=media.performer,
                             title=media.title
-                        ),
-                        raw.types.DocumentAttributeFilename(
-                            file_name=os.path.basename(media.media)
                         )
-                    ]
+                    ] + filename_attribute
                 )
-            elif re.match("^https?://", media.media):
+            elif is_external_url:
                 media = raw.types.InputMediaDocumentExternal(
                     url=media.media
                 )
             else:
                 media = utils.get_input_media_from_file_id(media.media, FileType.AUDIO)
         elif isinstance(media, types.InputMediaAnimation):
-            if os.path.isfile(media.media):
+            if is_uploaded_file:
                 media = raw.types.InputMediaUploadedDocument(
-                    mime_type=self.guess_mime_type(media.media) or "video/mp4",
+                    mime_type=(None if is_bytes_io else self.guess_mime_type(media.media)) or "video/mp4",
                     thumb=await self.save_file(media.thumb),
                     file=await self.save_file(media.media),
                     attributes=[
@@ -147,33 +162,26 @@ class EditInlineMedia:
                             w=media.width,
                             h=media.height
                         ),
-                        raw.types.DocumentAttributeFilename(
-                            file_name=os.path.basename(media.media)
-                        ),
                         raw.types.DocumentAttributeAnimated()
-                    ],
+                    ] + filename_attribute,
                     nosound_video=True
                 )
-            elif re.match("^https?://", media.media):
+            elif is_external_url:
                 media = raw.types.InputMediaDocumentExternal(
                     url=media.media
                 )
             else:
                 media = utils.get_input_media_from_file_id(media.media, FileType.ANIMATION)
         elif isinstance(media, types.InputMediaDocument):
-            if os.path.isfile(media.media):
+            if is_uploaded_file:
                 media = raw.types.InputMediaUploadedDocument(
-                    mime_type=self.guess_mime_type(media.media) or "application/zip",
+                    mime_type=(None if is_bytes_io else self.guess_mime_type(media.media)) or "application/zip",
                     thumb=await self.save_file(media.thumb),
                     file=await self.save_file(media.media),
-                    attributes=[
-                        raw.types.DocumentAttributeFilename(
-                            file_name=os.path.basename(media.media)
-                        )
-                    ],
+                    attributes=filename_attribute,
                     force_file=True
                 )
-            elif re.match("^https?://", media.media):
+            elif is_external_url:
                 media = raw.types.InputMediaDocumentExternal(
                     url=media.media
                 )
@@ -185,25 +193,37 @@ class EditInlineMedia:
 
         session = await get_session(self, dc_id)
 
-        actual_media = await self.invoke(
-            raw.functions.messages.UploadMedia(
-                peer=raw.types.InputPeerSelf(),
-                media=media
+
+        if is_uploaded_file:
+            uploaded_media = await self.invoke(
+                raw.functions.messages.UploadMedia(
+                    peer=raw.types.InputPeerSelf(),
+                    media=media
+                )
             )
-        )
+
+            actual_media = raw.types.InputMediaPhoto(
+                id=raw.types.InputPhoto(
+                    id=uploaded_media.photo.id,
+                    access_hash=uploaded_media.photo.access_hash,
+                    file_reference=uploaded_media.photo.file_reference
+                )
+            ) if is_photo else raw.types.InputMediaDocument(
+                id=raw.types.InputDocument(
+                    id=uploaded_media.document.id,
+                    access_hash=uploaded_media.document.access_hash,
+                    file_reference=uploaded_media.document.file_reference                    
+                )
+            )
+        else:
+            actual_media = media
 
         for i in range(self.MAX_RETRIES):
             try:
                 return await session.invoke(
                     raw.functions.messages.EditInlineBotMessage(
                         id=unpacked,
-                        media=raw.types.InputMediaDocument(
-                            id=raw.types.InputDocument(
-                                id=actual_media.document.id,
-                                access_hash=actual_media.document.access_hash,
-                                file_reference=actual_media.document.file_reference
-                            )
-                        ),
+                        media=actual_media,
                         reply_markup=await reply_markup.write(self) if reply_markup else None,
                         **await self.parser.parse(caption, parse_mode)
                     ),


### PR DESCRIPTION
⚠️ **Followup for https://github.com/pyrogram/pyrogram/pull/1036**

There was an issue with the previous Pull Request, which led to the method breaking with `InputMediaPhoto`.

## Fixes 🩹
 - Usage with InputMediaPhoto
 - Usage with BytesIO (anonymous BytesIO without a `.name` property is accepted as well)
 - Use `uploadMedia` only for newly uploaded documents/photos (files or BytesIO)

## Improvements ✨
 - Refactoring
 - Removed duplicated code
 - Add BytesIO name in `DocumentAttributeFilename`, fallbacks to `"media"` if a `.name` property is not set

## What I tested 🧪
 - Every InputMedia* with a local file
 - Every InputMedia* with a external url
 - Every InputMedia* with a named BytesIO media
 - Every InputMedia* with an anonymous (without `.name`) BytesIO media
 - Editing inline media in chats which DC is different by the bot's data center

I consider this a definitive fix for the method, as I couldn't reproduce any related issue anymore.