### PR TITLE
add min_id & max_id support in [messages.getHistory]

### DIFF
--- a/pyrogram/methods/messages/get_chat_history.py
+++ b/pyrogram/methods/messages/get_chat_history.py
@@ -30,7 +30,9 @@ async def get_chunk(
     limit: int = 0,
     offset: int = 0,
     from_message_id: int = 0,
-    from_date: datetime = utils.zero_datetime()
+    from_date: datetime = utils.zero_datetime(),
+    min_id: int = 0,
+    max_id: int = 0
 ):
     messages = await client.invoke(
         raw.functions.messages.GetHistory(
@@ -39,8 +41,8 @@ async def get_chunk(
             offset_date=utils.datetime_to_timestamp(from_date),
             add_offset=offset,
             limit=limit,
-            max_id=0,
-            min_id=0,
+            max_id=max_id,
+            min_id=min_id,
             hash=0
         ),
         sleep_threshold=60
@@ -56,7 +58,9 @@ class GetChatHistory:
         limit: int = 0,
         offset: int = 0,
         offset_id: int = 0,
-        offset_date: datetime = utils.zero_datetime()
+        offset_date: datetime = utils.zero_datetime(),
+        min_id: int = 0,
+        max_id: int = 0
     ) -> Optional[AsyncGenerator["types.Message", None]]:
         """Get messages from a chat history.
 
@@ -102,7 +106,9 @@ class GetChatHistory:
                 limit=limit,
                 offset=offset,
                 from_message_id=offset_id,
-                from_date=offset_date
+                from_date=offset_date,
+                min_id=min_id,
+                max_id=max_id
             )
 
             if not messages:


### PR DESCRIPTION
According to the official document (https://core.telegram.org/method/messages.getHistory)

max_id: Can be used to only return results with ID strictly smaller than max_id (e.g. message ID)
min_id: Can be used to only return results with ID strictly greater than min_id(e.g. message ID)

so added these parameters accordingly