### PR TITLE
Fixed `ValueError: with Custom Emoji Entity

### DIFF
--- a/pyrogram/enums/message_entity_type.py
+++ b/pyrogram/enums/message_entity_type.py
@@ -77,5 +77,8 @@ class MessageEntityType(AutoName):
     BANK_CARD = raw.types.MessageEntityBankCard
     "Bank card text"
 
+    EMOJI = raw.types.MessageEntityCustomEmoji
+    "Emoji Entity"
+
     UNKNOWN = raw.types.MessageEntityUnknown
     "Unknown message entity type"


### PR DESCRIPTION
Fixed `ValueError: <class 'pyrogram.raw.types.message_entity_custom_emoji.MessageEntityCustomEmoji'> is not a valid MessageEntityType`
