### PR TITLE
added `language` to entities when unparsing

### DIFF
--- a/pyrogram/parser/html.py
+++ b/pyrogram/parser/html.py
@@ -172,16 +172,13 @@ class HTML:
                 name = entity_type.name[0].lower()
                 start_tag = f"<{name}>"
                 end_tag = f"</{name}>"
-            elif entity_type == MessageEntityType.PRE and hasattr(
-                    entity,
-                    "language"
-            ) and entity.language not in [None, ""]:
+            elif entity_type == MessageEntityType.PRE:
                 name = entity_type.name.lower()
-                start_tag = f"<{name} language=\"{entity.language}\">"
+                language = getattr(entity, "language", "") or ""
+                start_tag = f'<{name} language="{language}">' if language else f"<{name}>"
                 end_tag = f"</{name}>"
             elif entity_type in (
                 MessageEntityType.CODE,
-                MessageEntityType.PRE,
                 MessageEntityType.BLOCKQUOTE,
                 MessageEntityType.SPOILER,
             ):

--- a/pyrogram/parser/html.py
+++ b/pyrogram/parser/html.py
@@ -172,6 +172,13 @@ class HTML:
                 name = entity_type.name[0].lower()
                 start_tag = f"<{name}>"
                 end_tag = f"</{name}>"
+            elif entity_type == MessageEntityType.PRE and hasattr(
+                    entity,
+                    "language"
+            ) and entity.language not in [None, ""]:
+                name = entity_type.name.lower()
+                start_tag = f"<{name} language=\"{entity.language}\">"
+                end_tag = f"</{name}>"
             elif entity_type in (
                 MessageEntityType.CODE,
                 MessageEntityType.PRE,

--- a/pyrogram/parser/html.py
+++ b/pyrogram/parser/html.py
@@ -61,7 +61,7 @@ class Parser(HTMLParser):
             entity = raw.types.MessageEntityCode
         elif tag == "pre":
             entity = raw.types.MessageEntityPre
-            extra["language"] = ""
+            extra["language"] = attrs.get("language", "")
         elif tag == "spoiler":
             entity = raw.types.MessageEntitySpoiler
         elif tag == "a":

--- a/pyrogram/parser/markdown.py
+++ b/pyrogram/parser/markdown.py
@@ -130,6 +130,12 @@ class Markdown:
                 start_tag = end_tag = STRIKE_DELIM
             elif entity_type == MessageEntityType.CODE:
                 start_tag = end_tag = CODE_DELIM
+            elif entity_type == MessageEntityType.PRE and hasattr(
+                    entity,
+                    "language"
+            ) and entity.language not in [None, ""]:
+                start_tag = f"{PRE_DELIM}{entity.language}\n"
+                end_tag = f"\n{PRE_DELIM}"
             elif entity_type in (MessageEntityType.PRE, MessageEntityType.BLOCKQUOTE):
                 start_tag = end_tag = PRE_DELIM
             elif entity_type == MessageEntityType.SPOILER:

--- a/pyrogram/parser/markdown.py
+++ b/pyrogram/parser/markdown.py
@@ -138,8 +138,8 @@ class Markdown:
                 start_tag = end_tag = CODE_DELIM
             elif entity_type == MessageEntityType.PRE:
                 language = getattr(entity, "language", "") or ""
-                start_tag = f"{PRE_DELIM}{language}"
-                end_tag = f"{PRE_DELIM}"
+                start_tag = f"{PRE_DELIM}{language}\n"
+                end_tag = f"\n{PRE_DELIM}"
             elif entity_type == MessageEntityType.BLOCKQUOTE:
                 start_tag = end_tag = PRE_DELIM
             elif entity_type == MessageEntityType.SPOILER:

--- a/pyrogram/parser/markdown.py
+++ b/pyrogram/parser/markdown.py
@@ -105,6 +105,12 @@ class Markdown:
                 delims.remove(delim)
                 tag = CLOSING_TAG.format(tag)
 
+            first_line = text[start:].split("\n")[0]
+            if first_line.startswith(PRE_DELIM):
+                text = utils.replace_once(
+                    text, f"{first_line}\n", f'<pre language="{first_line[len(PRE_DELIM):].strip()}">', start)
+                continue
+
             text = utils.replace_once(text, delim, tag, start)
 
         return await self.html.parse(text)
@@ -130,13 +136,11 @@ class Markdown:
                 start_tag = end_tag = STRIKE_DELIM
             elif entity_type == MessageEntityType.CODE:
                 start_tag = end_tag = CODE_DELIM
-            elif entity_type == MessageEntityType.PRE and hasattr(
-                    entity,
-                    "language"
-            ) and entity.language not in [None, ""]:
-                start_tag = f"{PRE_DELIM}{entity.language}\n"
+            elif entity_type == MessageEntityType.PRE:
+                language = getattr(entity, "language", "") or ""
+                start_tag = f"{PRE_DELIM}{language}\n"
                 end_tag = f"\n{PRE_DELIM}"
-            elif entity_type in (MessageEntityType.PRE, MessageEntityType.BLOCKQUOTE):
+            elif entity_type == MessageEntityType.BLOCKQUOTE:
                 start_tag = end_tag = PRE_DELIM
             elif entity_type == MessageEntityType.SPOILER:
                 start_tag = end_tag = SPOILER_DELIM

--- a/pyrogram/parser/markdown.py
+++ b/pyrogram/parser/markdown.py
@@ -105,10 +105,10 @@ class Markdown:
                 delims.remove(delim)
                 tag = CLOSING_TAG.format(tag)
 
-            first_line = text[start:].split("\n")[0]
-            if first_line.startswith(PRE_DELIM):
-                text = utils.replace_once(
-                    text, f"{first_line}\n", f'<pre language="{first_line[len(PRE_DELIM):].strip()}">', start)
+            if delim == PRE_DELIM and delim in delims:
+                delim_and_language = text[text.find(PRE_DELIM):].split("\n")[0]
+                language = delim_and_language[len(PRE_DELIM):]
+                text = utils.replace_once(text, delim_and_language, f'<pre language="{language}">', start)
                 continue
 
             text = utils.replace_once(text, delim, tag, start)
@@ -138,8 +138,8 @@ class Markdown:
                 start_tag = end_tag = CODE_DELIM
             elif entity_type == MessageEntityType.PRE:
                 language = getattr(entity, "language", "") or ""
-                start_tag = f"{PRE_DELIM}{language}\n"
-                end_tag = f"\n{PRE_DELIM}"
+                start_tag = f"{PRE_DELIM}{language}"
+                end_tag = f"{PRE_DELIM}"
             elif entity_type == MessageEntityType.BLOCKQUOTE:
                 start_tag = end_tag = PRE_DELIM
             elif entity_type == MessageEntityType.SPOILER:


### PR DESCRIPTION
Added the field `language` when unparsing `PRE` entities (both markdown and html), which was being completely ignored.
Not added when parsing (yet)