### PR TITLE
Type-Hint Fix

### DIFF
--- a/pyrogram/methods/messages/copy_message.py
+++ b/pyrogram/methods/messages/copy_message.py
@@ -45,7 +45,7 @@ class CopyMessage:
             "types.ReplyKeyboardRemove",
             "types.ForceReply"
         ] = None
-    ) -> types.Message:
+    ) -> "types.Message":
         """Copy messages of any kind.
 
         The method is analogous to the method :meth:`~Client.forward_messages`, but the copied message doesn't have a

--- a/pyrogram/methods/messages/copy_message.py
+++ b/pyrogram/methods/messages/copy_message.py
@@ -45,7 +45,7 @@ class CopyMessage:
             "types.ReplyKeyboardRemove",
             "types.ForceReply"
         ] = None
-    ) -> List["types.Message"]:
+    ) -> types.Message:
         """Copy messages of any kind.
 
         The method is analogous to the method :meth:`~Client.forward_messages`, but the copied message doesn't have a


### PR DESCRIPTION
Method returns Message type, but type-hint say's that method will return List of Message

> Returns:
            :obj:`~pyrogram.types.Message`: On success, the copied message is returned.
> > DOCSTRING

