### PR TITLE
Fix TypeError in method edit_message_media

### DIFF
--- a/pyrogram/methods/messages/edit_message_media.py
+++ b/pyrogram/methods/messages/edit_message_media.py
@@ -91,6 +91,9 @@ class EditMessageMedia:
         if caption is not None:
             message, entities = (await self.parser.parse(caption, parse_mode)).values()
 
+        is_bytes_io = isinstance(media.media, io.BytesIO)
+        file_name = file_name or (media.media.name if is_bytes_io else os.path.basename(media.media))
+
         if isinstance(media, types.InputMediaPhoto):
             if isinstance(media.media, io.BytesIO) or os.path.isfile(media.media):
                 media = await self.invoke(
@@ -121,7 +124,7 @@ class EditMessageMedia:
                     raw.functions.messages.UploadMedia(
                         peer=await self.resolve_peer(chat_id),
                         media=raw.types.InputMediaUploadedDocument(
-                            mime_type=self.guess_mime_type(media.media) or "video/mp4",
+                            mime_type=(None if is_bytes_io else self.guess_mime_type(media.media)) or "video/mp4",
                             thumb=await self.save_file(media.thumb),
                             file=await self.save_file(media.media),
                             attributes=[
@@ -132,7 +135,7 @@ class EditMessageMedia:
                                     h=media.height
                                 ),
                                 raw.types.DocumentAttributeFilename(
-                                    file_name=file_name or os.path.basename(media.media)
+                                    file_name=file_name
                                 )
                             ]
                         )
@@ -158,7 +161,7 @@ class EditMessageMedia:
                     raw.functions.messages.UploadMedia(
                         peer=await self.resolve_peer(chat_id),
                         media=raw.types.InputMediaUploadedDocument(
-                            mime_type=self.guess_mime_type(media.media) or "audio/mpeg",
+                            mime_type=(None if is_bytes_io else self.guess_mime_type(media.media)) or "audio/mpeg",
                             thumb=await self.save_file(media.thumb),
                             file=await self.save_file(media.media),
                             attributes=[
@@ -168,7 +171,7 @@ class EditMessageMedia:
                                     title=media.title
                                 ),
                                 raw.types.DocumentAttributeFilename(
-                                    file_name=file_name or os.path.basename(media.media)
+                                    file_name=file_name
                                 )
                             ]
                         )
@@ -194,7 +197,7 @@ class EditMessageMedia:
                     raw.functions.messages.UploadMedia(
                         peer=await self.resolve_peer(chat_id),
                         media=raw.types.InputMediaUploadedDocument(
-                            mime_type=self.guess_mime_type(media.media) or "video/mp4",
+                            mime_type=(None if is_bytes_io else self.guess_mime_type(media.media)) or "video/mp4",
                             thumb=await self.save_file(media.thumb),
                             file=await self.save_file(media.media),
                             attributes=[
@@ -205,7 +208,7 @@ class EditMessageMedia:
                                     h=media.height
                                 ),
                                 raw.types.DocumentAttributeFilename(
-                                    file_name=file_name or os.path.basename(media.media)
+                                    file_name=file_name
                                 ),
                                 raw.types.DocumentAttributeAnimated()
                             ]
@@ -232,12 +235,12 @@ class EditMessageMedia:
                     raw.functions.messages.UploadMedia(
                         peer=await self.resolve_peer(chat_id),
                         media=raw.types.InputMediaUploadedDocument(
-                            mime_type=self.guess_mime_type(media.media) or "application/zip",
+                            mime_type=(None if is_bytes_io else self.guess_mime_type(media.media)) or "application/zip",
                             thumb=await self.save_file(media.thumb),
                             file=await self.save_file(media.media),
                             attributes=[
                                 raw.types.DocumentAttributeFilename(
-                                    file_name=file_name or os.path.basename(media.media)
+                                    file_name=file_name
                                 )
                             ]
                         )


### PR DESCRIPTION
Fix "TypeError: expected str, bytes or os.PathLike object, not BytesIO" when passing an InputMedia with .media attribute being a BytesIO to method edit_message_media

test case

```python
...

client = Client(**config)
with client:
    doc_io = io.BytesIO(b'aabb123')
    doc_io.name = 'media'
    msg: pyrogram.types.Message = client.send_document(chat_id=test_channel, document=doc_io)
    doc_io.seek(0)
    msg.edit_media(InputMediaDocument(media=doc_io))  # <- got "TypeError: expected str, bytes or os.PathLike object, not BytesIO", fixed in this pr
```