### PR TITLE
Fix on_disconnect decorator not working

### DIFF
--- a/pyrogram/methods/decorators/on_disconnect.py
+++ b/pyrogram/methods/decorators/on_disconnect.py
@@ -32,6 +32,11 @@ class OnDisconnect:
         def decorator(func: Callable) -> Callable:
             if isinstance(self, pyrogram.Client):
                 self.add_handler(pyrogram.handlers.DisconnectHandler(func))
+            else:
+                if not hasattr(func, "handlers"):
+                    func.handlers = []
+
+                func.handlers.append((pyrogram.handlers.DisconnectHandler(func), 0))
 
             return func
 

--- a/pyrogram/methods/decorators/on_raw_update.py
+++ b/pyrogram/methods/decorators/on_raw_update.py
@@ -46,7 +46,7 @@ class OnRawUpdate:
                 func.handlers.append(
                     (
                         pyrogram.handlers.RawUpdateHandler(func),
-                        group if self is None else group
+                        group
                     )
                 )
 


### PR DESCRIPTION
Believe or not, this is the only handler that's not working

```py3
@Client.on_disconnect()
async def disconnect(client: Client):
    pass
````