### PR TITLE
Avoid redundant `Client.fetch_peers` calls

### DIFF
--- a/pyrogram/methods/advanced/resolve_peer.py
+++ b/pyrogram/methods/advanced/resolve_peer.py
@@ -89,16 +89,14 @@ class ResolvePeer:
             peer_type = utils.get_peer_type(peer_id)
 
             if peer_type == "user":
-                await self.fetch_peers(
-                    await self.invoke(
-                        raw.functions.users.GetUsers(
-                            id=[
-                                raw.types.InputUser(
-                                    user_id=peer_id,
-                                    access_hash=0
-                                )
-                            ]
-                        )
+                await self.invoke(
+                    raw.functions.users.GetUsers(
+                        id=[
+                            raw.types.InputUser(
+                                user_id=peer_id,
+                                access_hash=0
+                            )
+                        ]
                     )
                 )
             elif peer_type == "chat":

--- a/pyrogram/methods/chats/get_chat.py
+++ b/pyrogram/methods/chats/get_chat.py
@@ -67,8 +67,6 @@ class GetChat:
             if isinstance(r, raw.types.ChatInvite):
                 return types.ChatPreview._parse(self, r)
 
-            await self.fetch_peers([r.chat])
-
             if isinstance(r.chat, raw.types.Chat):
                 chat_id = -r.chat.id
 


### PR DESCRIPTION
Fixes #1174 