### PR TITLE
Improvements to automate tasks using pyrogram

### DIFF
--- a/pyrogram/methods/chats/join_chat.py
+++ b/pyrogram/methods/chats/join_chat.py
@@ -67,7 +67,7 @@ class JoinChat:
         else:
             chat = await self.invoke(
                 raw.functions.channels.JoinChannel(
-                    channel=await self.resolve_peer(chat_id)
+                    channel=await self.resolve_peer(chat_id.split('/')[-1])
                 )
             )
 


### PR DESCRIPTION
When a user has automated reading of chats/channels/groups content or has the message handler active, the links to the channels usually also appear in the following format: "https://t.me/telegram". Right now, we get a 400 error if we want to authenticate using the "https://t.me/telegram" link. 

<img width="1150" alt="Captura de Pantalla 2023-02-26 a las 15 54 56" src="https://user-images.githubusercontent.com/16117079/221418236-668591af-6704-496c-aead-c3951256975b.png">

With this improvement in line 70, the user can use either just the public channel nickname or the full link. It makes it easier for the user to use any type of link and he will have no problem accessing it.

<img width="240" alt="Captura de Pantalla 2023-02-26 a las 15 53 54" src="https://user-images.githubusercontent.com/16117079/221418087-5e202105-9aef-4f9b-be23-fb87da4b82a9.png">

With this change, apart from improving the usability of the library, some issues such as  "https://github.com/pyrogram/pyrogram/issues/1077" #1077 from August 2022 are also fixed.
