### PR TITLE
add drop_author parameter in methods/.../forward_messages.py

### DIFF
--- a/pyrogram/methods/messages/forward_messages.py
+++ b/pyrogram/methods/messages/forward_messages.py
@@ -32,7 +32,8 @@ class ForwardMessages:
         message_ids: Union[int, Iterable[int]],
         disable_notification: bool = None,
         schedule_date: datetime = None,
-        protect_content: bool = None
+        protect_content: bool = None,
+        drop_author: bool = None
     ) -> Union["types.Message", List["types.Message"]]:
         """Forward messages of any kind.
 
@@ -62,6 +63,9 @@ class ForwardMessages:
             protect_content (``bool``, *optional*):
                 Protects the contents of the sent message from forwarding and saving.
 
+            drop_author (``bool``, *optional*):
+                Forwards messages without quoting the original author
+
         Returns:
             :obj:`~pyrogram.types.Message` | List of :obj:`~pyrogram.types.Message`: In case *message_ids* was not
             a list, a single message is returned, otherwise a list of messages is returned.
@@ -87,7 +91,8 @@ class ForwardMessages:
                 silent=disable_notification or None,
                 random_id=[self.rnd_id() for _ in message_ids],
                 schedule_date=utils.datetime_to_timestamp(schedule_date),
-                noforwards=protect_content
+                noforwards=protect_content,
+                drop_author=drop_author
             )
         )
 


### PR DESCRIPTION

Issue #1211 





## My manual tests

### Expect: Default forwarding

- 1 message with drop_author (D.A.) = None (default) - **OK**
- list of messages, D.A. = None (default) - **OK**

### Expect: Same behavior
- 1 message, D.A. = False - **OK**
- list of messages, D.A. = False (default) - **OK**

### Expect: Forward without author account
- 1 message, D.A. = True - **OK**
- list of messages, D.A. = True (default) - **OK**
