### PR TITLE
Fix a bug and add ByteIO to thumb in input medias

### DIFF
--- a/pyrogram/methods/messages/edit_message_media.py
+++ b/pyrogram/methods/messages/edit_message_media.py
@@ -124,7 +124,7 @@ class EditMessageMedia:
                     raw.functions.messages.UploadMedia(
                         peer=await self.resolve_peer(chat_id),
                         media=raw.types.InputMediaUploadedDocument(
-                            mime_type=self.guess_mime_type(media.media) or "video/mp4",
+                            mime_type=self.guess_mime_type(file_name or media.media.name) or "video/mp4",
                             thumb=await self.save_file(media.thumb),
                             spoiler=media.has_spoiler,
                             file=await self.save_file(media.media),
@@ -164,7 +164,7 @@ class EditMessageMedia:
                     raw.functions.messages.UploadMedia(
                         peer=await self.resolve_peer(chat_id),
                         media=raw.types.InputMediaUploadedDocument(
-                            mime_type=self.guess_mime_type(media.media) or "audio/mpeg",
+                            mime_type=self.guess_mime_type(file_name or media.media.name) or "audio/mpeg",
                             thumb=await self.save_file(media.thumb),
                             file=await self.save_file(media.media),
                             attributes=[
@@ -200,7 +200,7 @@ class EditMessageMedia:
                     raw.functions.messages.UploadMedia(
                         peer=await self.resolve_peer(chat_id),
                         media=raw.types.InputMediaUploadedDocument(
-                            mime_type=self.guess_mime_type(media.media) or "video/mp4",
+                            mime_type=self.guess_mime_type(file_name or media.media.name) or "video/mp4",
                             thumb=await self.save_file(media.thumb),
                             spoiler=media.has_spoiler,
                             file=await self.save_file(media.media),
@@ -241,7 +241,7 @@ class EditMessageMedia:
                     raw.functions.messages.UploadMedia(
                         peer=await self.resolve_peer(chat_id),
                         media=raw.types.InputMediaUploadedDocument(
-                            mime_type=self.guess_mime_type(media.media) or "application/zip",
+                            mime_type=self.guess_mime_type(file_name or media.media.name) or "application/zip",
                             thumb=await self.save_file(media.thumb),
                             file=await self.save_file(media.media),
                             attributes=[

--- a/pyrogram/types/input_media/input_media.py
+++ b/pyrogram/types/input_media/input_media.py
@@ -37,7 +37,7 @@ class InputMedia(Object):
     def __init__(
         self,
         media: Union[str, BinaryIO],
-        caption: str = "",
+        caption: str = None,
         parse_mode: str = None,
         caption_entities: List[MessageEntity] = None
     ):

--- a/pyrogram/types/input_media/input_media_animation.py
+++ b/pyrogram/types/input_media/input_media_animation.py
@@ -68,7 +68,7 @@ class InputMediaAnimation(InputMedia):
         self,
         media: Union[str, BinaryIO],
         thumb: str = None,
-        caption: str = "",
+        caption: Union[str, BinaryIO] = None,
         parse_mode: Optional["enums.ParseMode"] = None,
         caption_entities: List[MessageEntity] = None,
         width: int = 0,

--- a/pyrogram/types/input_media/input_media_audio.py
+++ b/pyrogram/types/input_media/input_media_audio.py
@@ -66,8 +66,8 @@ class InputMediaAudio(InputMedia):
     def __init__(
         self,
         media: Union[str, BinaryIO],
-        thumb: str = None,
-        caption: str = "",
+        thumb: Union[str, BinaryIO] = None,
+        caption: str = None,
         parse_mode: Optional["enums.ParseMode"] = None,
         caption_entities: List[MessageEntity] = None,
         duration: int = 0,

--- a/pyrogram/types/input_media/input_media_document.py
+++ b/pyrogram/types/input_media/input_media_document.py
@@ -55,8 +55,8 @@ class InputMediaDocument(InputMedia):
     def __init__(
         self,
         media: Union[str, BinaryIO],
-        thumb: str = None,
-        caption: str = "",
+        thumb: Union[str, BinaryIO] = None,
+        caption: str = None,
         parse_mode: Optional["enums.ParseMode"] = None,
         caption_entities: List[MessageEntity] = None
     ):

--- a/pyrogram/types/input_media/input_media_photo.py
+++ b/pyrogram/types/input_media/input_media_photo.py
@@ -53,7 +53,7 @@ class InputMediaPhoto(InputMedia):
     def __init__(
         self,
         media: Union[str, BinaryIO],
-        caption: str = "",
+        caption: str = None,
         parse_mode: Optional["enums.ParseMode"] = None,
         caption_entities: List[MessageEntity] = None,
         has_spoiler: bool = None

--- a/pyrogram/types/input_media/input_media_video.py
+++ b/pyrogram/types/input_media/input_media_video.py
@@ -71,8 +71,8 @@ class InputMediaVideo(InputMedia):
     def __init__(
         self,
         media: Union[str, BinaryIO],
-        thumb: str = None,
-        caption: str = "",
+        thumb: Union[str, BinaryIO] = None,
+        caption: str = None,
         parse_mode: Optional["enums.ParseMode"] = None,
         caption_entities: List[MessageEntity] = None,
         width: int = 0,


### PR DESCRIPTION
When you want only edit media of message with edit_message_media, it will remove caption of media because  "" (empty string) have been set as default in input_media_auido (and others which have caption) which will remove caption.

Added ByteIO in some of input medias that support thumbnail.

in guess_mime_type of edit_message_media instead of filename, media was given. when we pass ByteIO to media it will throw error.