### PR TITLE
Fix type hint for `InputMediaVideo`’s `thumb` attribute

### DIFF
--- a/pyrogram/types/input_media/input_media_video.py
+++ b/pyrogram/types/input_media/input_media_video.py
@@ -35,7 +35,7 @@ class InputMediaVideo(InputMedia):
             pass a binary file-like object with its attribute “.name” set for in-memory uploads or
             pass an HTTP URL as a string for Telegram to get a video from the Internet.
 
-        thumb (``str``):
+        thumb (``str`` | ``BinaryIO``):
             Thumbnail of the video sent.
             The thumbnail should be in JPEG format and less than 200 KB in size.
             A thumbnail's width and height should not exceed 320 pixels.
@@ -71,7 +71,7 @@ class InputMediaVideo(InputMedia):
     def __init__(
         self,
         media: Union[str, BinaryIO],
-        thumb: str = None,
+        thumb: str | BinaryIO = None,
         caption: str = "",
         parse_mode: Optional["enums.ParseMode"] = None,
         caption_entities: List[MessageEntity] = None,


### PR DESCRIPTION
The thumb attribute can also be a `BinaryIO` as it is [passed](https://github.com/pyrogram/pyrogram/blob/master/pyrogram/methods/messages/send_media_group.py#L165) to a method in a position that can also accept a `BinaryIO`.