### PR TITLE
fix misspelling function name in example

### DIFF
--- a/pyrogram/methods/messages/get_chat_history_count.py
+++ b/pyrogram/methods/messages/get_chat_history_count.py
@@ -50,7 +50,7 @@ class GetChatHistoryCount:
         Example:
             .. code-block:: python
 
-                await app.get_history_count(chat_id)
+                await app.get_chat_history_count(chat_id)
         """
 
         r = await self.invoke(


### PR DESCRIPTION
Fixed misspelling function name in get_chat_history_count example