### PR TITLE
get_chat_history: add min_id & max_id parameters

### DIFF
--- a/pyrogram/methods/messages/get_chat_history.py
+++ b/pyrogram/methods/messages/get_chat_history.py
@@ -29,6 +29,8 @@ async def get_chunk(
     chat_id: Union[int, str],
     limit: int = 0,
     offset: int = 0,
+    min_id: int = 0,
+    max_id: int = 0,
     from_message_id: int = 0,
     from_date: datetime = utils.zero_datetime()
 ):
@@ -39,8 +41,8 @@ async def get_chunk(
             offset_date=utils.datetime_to_timestamp(from_date),
             add_offset=offset,
             limit=limit,
-            max_id=0,
-            min_id=0,
+            max_id=max_id,
+            min_id=min_id,
             hash=0
         ),
         sleep_threshold=60
@@ -56,6 +58,8 @@ class GetChatHistory:
         limit: int = 0,
         offset: int = 0,
         offset_id: int = 0,
+        min_id: int = 0,
+        max_id: int = 0,
         offset_date: datetime = utils.zero_datetime()
     ) -> Optional[AsyncGenerator["types.Message", None]]:
         """Get messages from a chat history.
@@ -104,6 +108,8 @@ class GetChatHistory:
                 limit=limit,
                 offset=offset,
                 from_message_id=offset_id,
+                min_id=min_id,
+                max_id=max_id,
                 from_date=offset_date
             )
 


### PR DESCRIPTION
I'm switching lib from telethon because poor perfs, good news is that I retreive messages instantly now, was not the case with telethon.

But the way my code works I keep track of the last (most recent) message retreived from history - this is conveniently handled via `min_id` param to Telegram's API, which is not passed down to base request in pyrogram. (`offset_id` does the work in reverse, probably acting like similar to `max_id`, not sure if there is a difference)

So here is my small contribution. I've also added `max_id` along the way but reflecting on what I just said maybe it would add confusion.

This does the job for me, could help others. Could also be included in `get_messages` and `search_messages` perhaps, for now I only use `get_chat_history`.