### PR TITLE
Fix `AttributeError` in `ChatType` filters

### DIFF
--- a/pyrogram/filters.py
+++ b/pyrogram/filters.py
@@ -440,6 +440,7 @@ media_spoiler = create(media_spoiler_filter)
 
 # region private_filter
 async def private_filter(_, __, m: Message):
+    m = m.message if isinstance(m, CallbackQuery) else m
     return bool(m.chat and m.chat.type in {enums.ChatType.PRIVATE, enums.ChatType.BOT})
 
 
@@ -451,6 +452,7 @@ private = create(private_filter)
 
 # region group_filter
 async def group_filter(_, __, m: Message):
+    m = m.message if isinstance(m, CallbackQuery) else m
     return bool(m.chat and m.chat.type in {enums.ChatType.GROUP, enums.ChatType.SUPERGROUP})
 
 
@@ -462,6 +464,7 @@ group = create(group_filter)
 
 # region channel_filter
 async def channel_filter(_, __, m: Message):
+    m = m.message if isinstance(m, CallbackQuery) else m
     return bool(m.chat and m.chat.type == enums.ChatType.CHANNEL)
 
 

--- a/pyrogram/parser/html.py
+++ b/pyrogram/parser/html.py
@@ -182,7 +182,6 @@ class HTML:
                 MessageEntityType.BLOCKQUOTE,
                 MessageEntityType.SPOILER,
             ):
-                print(name)
                 name = entity_type.name.lower()
                 start_tag = f"<{name}>"
                 end_tag = f"</{name}>"

--- a/pyrogram/parser/html.py
+++ b/pyrogram/parser/html.py
@@ -182,6 +182,7 @@ class HTML:
                 MessageEntityType.BLOCKQUOTE,
                 MessageEntityType.SPOILER,
             ):
+                print(name)
                 name = entity_type.name.lower()
                 start_tag = f"<{name}>"
                 end_tag = f"</{name}>"


### PR DESCRIPTION
Fixed a bug caused by: `AttributeError: 'CallbackQuery' object has no attribute 'chat'`, also related to Issue #1273

#### Full TraceBack:

```'
CallbackQuery' object has no attribute 'chat'
Traceback (most recent call last):
  File "C:\Users\Gustavo\AppData\Local\Programs\Python\Python312\Lib\site-packages\pyrogram\dispatcher.py", line 226, in handler_worker
    if await handler.check(self.client, parsed_update):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    return await self.filters(client, update)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Gustavo\AppData\Local\Programs\Python\Python312\Lib\site-packages\pyrogram\filters.py", line 79, in __call__
    y = await self.other(client, update)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Gustavo\AppData\Local\Programs\Python\Python312\Lib\site-packages\pyrogram\filters.py", line 443, in private_filter
    return bool(m.chat and m.chat.type in {enums.ChatType.PRIVATE, enums.ChatType.BOT})
                ^^^^^^
AttributeError: 'CallbackQuery' object has no attribute 'chat'
```