### PR TITLE
Update forward_messages.py add a method  to ForwardMessages

### DIFF
--- a/pyrogram/methods/messages/forward_messages.py
+++ b/pyrogram/methods/messages/forward_messages.py
@@ -108,3 +108,50 @@ class ForwardMessages:
                 )
 
         return types.List(forwarded_messages) if is_iterable else forwarded_messages[0]
+
+    async def forward_messages_noqoute(
+        self: "pyrogram.Client",
+        chat_id: Union[int, str],
+        from_chat_id: Union[int, str],
+        message_ids: Union[int, Iterable[int]],
+        disable_notification: bool = None,
+        schedule_date: datetime = None,
+        protect_content: bool = None
+    ) -> Union["types.Message", List["types.Message"]]:
+        """
+        exactly same as forward_messages method but this method won't show the sender name.
+        """
+
+        is_iterable = not isinstance(message_ids, int)
+        message_ids = list(message_ids) if is_iterable else [message_ids]
+
+        r = await self.invoke(
+            raw.functions.messages.ForwardMessages(
+                to_peer=await self.resolve_peer(chat_id),
+                from_peer=await self.resolve_peer(from_chat_id),
+                id=message_ids,
+                silent=disable_notification or None,
+                random_id=[self.rnd_id() for _ in message_ids],
+                schedule_date=utils.datetime_to_timestamp(schedule_date),
+                noforwards=protect_content,
+                drop_author=True
+            )
+        )
+
+        forwarded_messages = []
+
+        users = {i.id: i for i in r.users}
+        chats = {i.id: i for i in r.chats}
+
+        for i in r.updates:
+            if isinstance(i, (raw.types.UpdateNewMessage,
+                              raw.types.UpdateNewChannelMessage,
+                              raw.types.UpdateNewScheduledMessage)):
+                forwarded_messages.append(
+                    await types.Message._parse(
+                        self, i.message,
+                        users, chats
+                    )
+                )
+
+        return types.List(forwarded_messages) if is_iterable else forwarded_messages[0]


### PR DESCRIPTION
Adding a method to ForwardMessages class that works like forward_messages but it won't mention the sender name.