### PR TITLE
Edit AUDIO_VIDEO_NOTE message to filter InputMessagesFilterRoundVoice

### DIFF
--- a/pyrogram/enums/messages_filter.py
+++ b/pyrogram/enums/messages_filter.py
@@ -50,7 +50,7 @@ class MessagesFilter(AutoName):
     VIDEO_NOTE = raw.types.InputMessagesFilterRoundVideo
     "Video note messages"
 
-    AUDIO_VIDEO_NOTE = raw.types.InputMessagesFilterRoundVideo
+    AUDIO_VIDEO_NOTE = raw.types.InputMessagesFilterRoundVoice
     "Audio and video note messages"
 
     AUDIO = raw.types.InputMessagesFilterMusic


### PR DESCRIPTION
`pyrogram.enum.MessageFilter.AUDIO_VIDEO_NOTE` should be  
`raw.types.InputMessagesFilterRoundVoice` (for voice and video notes), and not  
`raw.types.InputMessagesFilterRoundVideo` (for voice notes only)