### PR TITLE
add reverse parameter on get_chat_history

### DIFF
--- a/pyrogram/methods/messages/get_chat_history.py
+++ b/pyrogram/methods/messages/get_chat_history.py
@@ -54,6 +54,7 @@ class GetChatHistory:
         self: "pyrogram.Client",
         chat_id: Union[int, str],
         limit: int = 0,
+        reverse: bool = False,
         offset: int = 0,
         offset_id: int = 0,
         offset_date: datetime = utils.zero_datetime()
@@ -74,6 +75,11 @@ class GetChatHistory:
                 Limits the number of messages to be retrieved.
                 By default, no limit is applied and all messages are returned.
 
+            reverse (``bool``, *optional*):
+                Set the direction of messages.
+                By default, from the most recent time to the oldest time.
+                From the oldest time to the most recent time on reverse is True.
+                
             offset (``int``, *optional*):
                 Sequential number of the first message to be returned..
                 Negative values are also accepted and become useful in case you set offset_id or offset_date.
@@ -110,6 +116,9 @@ class GetChatHistory:
             if not messages:
                 return
 
+            if reverse:
+                messages = list(reversed(messages))
+                
             offset_id = messages[-1].id
 
             for message in messages:


### PR DESCRIPTION
Hi, every nice guys in pyrogram. I want add one parameter so we can set the async_generator direction in get_chat_history. When I use the function 'get_chat_history', i want set the messages from the oldest to the newest. so I add reverse for that, If there is another way to achieve that without changing the library source code, please let me  know. 🤝🤝🤝
