### PR TITLE
Lower the MIN_CHANNEL_ID to fix the Invalid Peer Id error

### DIFF
--- a/pyrogram/utils.py
+++ b/pyrogram/utils.py
@@ -198,7 +198,7 @@ def unpack_inline_message_id(inline_message_id: str) -> "raw.base.InputBotInline
         )
 
 
-MIN_CHANNEL_ID = -1002147483647
+MIN_CHANNEL_ID = -1009999999999
 MAX_CHANNEL_ID = -1000000000000
 MIN_CHAT_ID = -2147483647
 MAX_USER_ID_OLD = 2147483647


### PR DESCRIPTION
Changed MIN_CHANNEL_ID so we dont face error on other channels.

Previously it was on -1002147483647, that threw errors on some channels like https://t.me/c/2164990312/1 That are legit channels but their chat_id isnt in the range specified.

This fix addresses the issue #1314 